### PR TITLE
add input and output options

### DIFF
--- a/lib/ember-cli-migrator
+++ b/lib/ember-cli-migrator
@@ -10,15 +10,19 @@ var path = require('path');
 
 program
   .version('0.0.1')
-  .option('-g, --global [name]', 'Add peppers')
+  .option('-g, --global [name]', 'Global namespace of Ember application, eg: "MyApplication = Ember.Application.."')
+  .option('-d, --directory [name]', 'Location of Ember application codebase')
+  .option('-s, --source [source_directory]', 'Directory to perform migration on')
+  .option('-t, --target [target_directory]',  'Directory to output result of migration')
   .parse(process.argv);
 
 var curDir = './';
 var tmpDir = path.join(curDir, "/tmp");
+
 var migrator = new EmberMigrator({
-  inputDirectory: curDir,
-  outputDirectory: tmpDir,
-  appName: 'my-app',
+  inputDirectory: program.source || curDir,
+  outputDirectory: program.target || tmpDir,
+  appName: program.directory,
   rootAppName: program.global
 });
 


### PR DESCRIPTION
Makes it a bit easier to decide where to apply transformations. This was actually needed because the migrator was going into my `node_modules` and performing operations there which I don't think is wanted (haven't used ember-cli yet). I'll make a separate issue for that.
