### PR TITLE
Use single quoted strings for ES6 module names

### DIFF
--- a/lib/ember-migrator.js
+++ b/lib/ember-migrator.js
@@ -219,7 +219,7 @@ EmberMigrator.prototype.convertFile = function(typedExport){
   visitor.visit(typedExport.astNodes);
   var imports = Object.keys(visitor.imports).map(function(key){
     var importFilename = typedExport.convertToOutputFilename(visitor.imports[key]);
-    return "import " + key + " from \"" + importFilename + '";';
+    return 'import ' + key + ' from \'' + importFilename + '\';';
   }, this).join("\n");
 
   imports = imports.replace('.js', '');

--- a/test/fixtures/custom_app_name/output/models/comment-activity.js
+++ b/test/fixtures/custom_app_name/output/models/comment-activity.js
@@ -1,4 +1,4 @@
-import Ember from "ember";
+import Ember from 'ember';
 
 var CommentActivity = Ember.Object.extend({
   someProperty: function(){

--- a/test/fixtures/vanilla/output/controllers/comment-activity.js
+++ b/test/fixtures/vanilla/output/controllers/comment-activity.js
@@ -1,4 +1,4 @@
-import Ember from "ember";
+import Ember from 'ember';
 
 var CommentActivityController = Ember.ObjectController.extend({
   someControllerProperty: 'props'

--- a/test/fixtures/vanilla/output/mixins/known-type.js
+++ b/test/fixtures/vanilla/output/mixins/known-type.js
@@ -1,4 +1,4 @@
-import Ember from "ember";
+import Ember from 'ember';
 
 var KnownTypeMixin = Ember.Mixin.create({
   iKnowStuff: 'stuff'

--- a/test/fixtures/vanilla/output/mixins/useful.js
+++ b/test/fixtures/vanilla/output/mixins/useful.js
@@ -1,4 +1,4 @@
-import Ember from "ember";
+import Ember from 'ember';
 
 var UsefulMixin = Ember.Mixin.create({
   useThisProperty: 'props'

--- a/test/fixtures/vanilla/output/models/comment-activity-with-ds.js
+++ b/test/fixtures/vanilla/output/models/comment-activity-with-ds.js
@@ -1,4 +1,4 @@
-import DS from "ember-data";
+import DS from 'ember-data';
 
 var CommentActivityWithDS = DS.Model.extend({
   title: DS.attr('string'),

--- a/test/fixtures/vanilla/output/models/comment-activity-with-em.js
+++ b/test/fixtures/vanilla/output/models/comment-activity-with-em.js
@@ -1,4 +1,4 @@
-import Ember from "ember";
+import Ember from 'ember';
 
 var CommentActivityWithEm = Ember.Object.extend({
   someProperty: function(){

--- a/test/fixtures/vanilla/output/models/comment-activity-with-path-for-type.js
+++ b/test/fixtures/vanilla/output/models/comment-activity-with-path-for-type.js
@@ -1,4 +1,4 @@
-import Ember from "ember";
+import Ember from 'ember';
 
 var CommentActivityWithPathForType = Ember.Object.extend({
   someProperty: function(){

--- a/test/fixtures/vanilla/output/models/comment-activity.js
+++ b/test/fixtures/vanilla/output/models/comment-activity.js
@@ -1,4 +1,4 @@
-import Ember from "ember";
+import Ember from 'ember';
 
 var CommentActivity = Ember.Object.extend({
   someProperty: function(){

--- a/test/fixtures/vanilla/output/models/extended-comment-activity.js
+++ b/test/fixtures/vanilla/output/models/extended-comment-activity.js
@@ -1,4 +1,4 @@
-import CommentActivity from "/my-app/models/comment-activity";
+import CommentActivity from '/my-app/models/comment-activity';
 
 var ExtendedCommentActivity = CommentActivity.extend({
   someProperty: function(){

--- a/test/fixtures/vanilla/output/models/user.js
+++ b/test/fixtures/vanilla/output/models/user.js
@@ -1,4 +1,4 @@
-import Ember from "ember";
+import Ember from 'ember';
 
 var User = Ember.Object.extend({
   someProperty: function(){

--- a/test/fixtures/vanilla/output/serializers/comment-activity.js
+++ b/test/fixtures/vanilla/output/serializers/comment-activity.js
@@ -1,4 +1,4 @@
-import DS from "ember-data";
+import DS from 'ember-data';
 
 var CommentActivitySerializer = DS.Serializer.extend({
   someProperty: function(){

--- a/test/fixtures/vanilla/output/serializers/user.js
+++ b/test/fixtures/vanilla/output/serializers/user.js
@@ -1,4 +1,4 @@
-import DS from "ember-data";
+import DS from 'ember-data';
 
 var UserSerializer = DS.Serializer.extend({
   someProperty: function(){

--- a/test/fixtures/vanilla/output/unknown_type/misc.js
+++ b/test/fixtures/vanilla/output/unknown_type/misc.js
@@ -1,4 +1,4 @@
-import Ember from "ember";
+import Ember from 'ember';
 
 var Misc = Ember.Object.extend({
   someProperty: function(){

--- a/test/fixtures/vanilla/output/views/comment-activity.js
+++ b/test/fixtures/vanilla/output/views/comment-activity.js
@@ -1,4 +1,4 @@
-import Ember from "ember";
+import Ember from 'ember';
 
 var CommentActivityView = Ember.View.extend({
   someViewProperty: 'props'


### PR DESCRIPTION
The ember-cli blueprints use [single quoted strings](https://github.com/stefanpenner/ember-cli/blob/master/blueprints/controller/files/app/__path__/__name__.js)
Before: 

``` js
import Ember from "ember";
```

After 

``` js
import Ember from 'ember';
```
