### PR TITLE
More canonical router test and output

### DIFF
--- a/test/fixtures/vanilla/input/router.js
+++ b/test/fixtures/vanilla/input/router.js
@@ -4,7 +4,11 @@ App.Router = Ember.Router.extend({
   }
 });
 
-Router.map(function() {
+App.Router.reopen({
+  location: 'auto'
+});
+
+App.Router.map(function() {
   this.resource('myresource', {path:'/myresource/:resource_id'}, function(){
     this.route('details');
   });

--- a/test/fixtures/vanilla/output/router.js
+++ b/test/fixtures/vanilla/output/router.js
@@ -5,6 +5,9 @@ var Router = Ember.Router.extend({
     console.log('hello');
   }
 });
+Router.reopen({
+  location: 'auto'
+});
 Router.map(function() {
   this.resource('myresource', {path:'/myresource/:resource_id'}, function(){
     this.route('details');


### PR DESCRIPTION
This is a more canonical router test than previous version. #21 fixes this test case. Give so this is dependant on that PR
```js
App.Router.reopen({
  location: 'auto'
});

App.Router.map(function() {
   this.resource('myresource', {path:'/myresource/:resource_id'}, function(){
     this.route('details');
   });
 })
```
