### PR TITLE
add git commit at move files and git add at modify files

### DIFF
--- a/lib/ember-migrator.js
+++ b/lib/ember-migrator.js
@@ -5,6 +5,7 @@ var recast = require('recast');
 var string = require('underscore.string');
 var fs = require('fs');
 var TypedExport = require('./typed-export');
+var execSync = require('exec-sync');
 
 // Recast helpers
 var builders = recast.types.builders;
@@ -122,11 +123,15 @@ EmberMigrator.prototype.run = function EmberMigrator_run(){
 
   console.log('process');
   Object.keys(this.splitFiles).forEach(function(key) {
-    self.processFile(self.splitFiles[key]);
-  });
-  console.log('flush');
-  this.flushConvertedFiles(this.splitFiles);
+    var file = self.splitFiles[key];
+    if(fs.existsSync(file.oldFileName)) {
+      var folder = file.outputFolderPath(this.appName);
+      mkdirp.sync(folder);
+      var outputPath = file.outputFilePath(this.appName);
 
+      execSync("git mv " + file.oldFileName + " " + outputPath);
+    }
+  }, this);
 
   nonJsFiles.forEach(function (filePath) {
     var fullPath = path.join(self.inputDirectory, filePath);
@@ -152,10 +157,20 @@ EmberMigrator.prototype.run = function EmberMigrator_run(){
     fs.writeFileSync(outputFile, fs.readFileSync(fullPath));
   });
 
+  execSync("git commit -m 'auto-commit from ember-cli-migrator'");
+  Object.keys(this.splitFiles).forEach(function(key) {
+    self.processFile(self.splitFiles[key]);
+  });
+
+  console.log('flush');
+  this.flushConvertedFiles(this.splitFiles);
+
+  execSync("git add  " + this.outputDirectory);
 };
 
 EmberMigrator.prototype.splitFile = function(filePath) {
   var file = fs.readFileSync(path.join(this.inputDirectory, filePath)).toString();
+  var oldFilePath = path.join(this.inputDirectory, filePath);
   var ast = recast.parse(file);
   var astBody = ast.program.body;
   var assignmentCount = 0;
@@ -179,7 +194,8 @@ EmberMigrator.prototype.splitFile = function(filePath) {
         fileName: fileName,
         // TODO(Tony) this will be a problem if a non-exporting node is found
         // first, because className will be null
-        exportName: className
+        exportName: className,
+        oldFileName: oldFilePath
       });
       that.splitFiles[fileName] = typedExport;
       // Every typed export needs to be able to be looked up on this map

--- a/lib/typed-export.js
+++ b/lib/typed-export.js
@@ -12,6 +12,7 @@ function TypedExport(options) {
   // Set the export name for the module
   this.exportName = options.exportName;
   this.fileName = options.fileName;
+  this.oldFileName = options.oldFileName;
 }
 
 TypedExport.prototype = Object.create(null);

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.2.2",
   "dependencies": {
     "commander": "^2.5.0",
+    "exec-sync": "^0.1.6",
     "mkdirp": "^0.5.0",
     "recast": "^0.8.0",
     "rsvp": "^3.0.14",


### PR DESCRIPTION
This commit adds a `git commit` command after moving all the files and a `git add` command after the moved files are split and modified for ES6. This preserves git history for the files during the migration.

This was mostly me typing while @fivetanley taught me the ins & outs of the migrator tool, thanks! :smile_cat: 