### PR TITLE
Log filenames while parsing.

### DIFF
--- a/lib/ember-migrator.js
+++ b/lib/ember-migrator.js
@@ -176,8 +176,15 @@ EmberMigrator.prototype.writeLine = function(message){
 EmberMigrator.prototype.splitFile = function(filePath) {
   var file = fs.readFileSync(path.join(this.inputDirectory, filePath)).toString();
   var oldFilePath = path.join(this.inputDirectory, filePath);
-  this.writeLine(chalk.green('Parsing ' + filePath));
-  var ast = recast.parse(file);
+  try {
+    var ast = recast.parse(file);
+  } catch (e) {
+    this.writeLine(chalk.red('Failed to parse ' + filePath));
+    if ( filePath.indexOf("node_modules") || filePath.indexOf("bower_components") ) {
+      this.writeLine(chalk.yellow("Note that you probably don't want to run the migrator against your npm or bower dependencies. Make sure that the directory you've specified in the '--source' flag only contains your application code."));
+    }
+    this.writeLine(chalk.grey(e));
+  }
   var astBody = ast.program.body;
   var assignmentCount = 0;
   // Cache of ast nodes that are not directly exported so need to be appended

--- a/lib/ember-migrator.js
+++ b/lib/ember-migrator.js
@@ -176,6 +176,7 @@ EmberMigrator.prototype.writeLine = function(message){
 EmberMigrator.prototype.splitFile = function(filePath) {
   var file = fs.readFileSync(path.join(this.inputDirectory, filePath)).toString();
   var oldFilePath = path.join(this.inputDirectory, filePath);
+  this.writeLine(chalk.green('Parsing ' + filePath));
   var ast = recast.parse(file);
   var astBody = ast.program.body;
   var assignmentCount = 0;


### PR DESCRIPTION
This is an (extremely simple) attempt to resolve #31.

If esprima encounters a token it doesn't like, it dies without any useful error info (not even a mention of what the token is), and the user is left with no place to start debugging.  All I did was change splitFile() to log the filename it's working on, which in my case was enough to fix the issue.

Maintainers:  if you'd prefer a command-line --verbose flag to trigger this and keep it less chatty in normal use, let me know.  Thanks for building a super useful utility!  :heart: :heart: :heart: 