### PR TITLE
Commonjs export support

### DIFF
--- a/lib/ember-migrator.js
+++ b/lib/ember-migrator.js
@@ -330,8 +330,10 @@ EmberMigrator.prototype.processFile = function(typedExport){
 
 EmberMigrator.prototype.convertFile = function(typedExport){
   var visitor = new MigratorVisitor({
+    localAppName: this.appName,
     rootAppName: this.rootAppName,
-    classesFilepathMap: this.classesFilepathMap
+    classesFilepathMap: this.classesFilepathMap,
+    outputDirectory: this.outputDirectory
   });
   visitor.visit(typedExport.astNodes);
   var imports = Object.keys(visitor.imports)

--- a/lib/ember-migrator.js
+++ b/lib/ember-migrator.js
@@ -291,6 +291,17 @@ EmberMigrator.prototype.splitFile = function(filePath) {
           isNodeStored = true;
         }
       }.bind(this));
+
+      // Check to see if the expression is a commonjs export
+      if (namedTypes.AssignmentExpression.check(node.expression) &&
+          node.expression.left.object.name === 'module' &&
+          node.expression.left.property.name === 'exports') {
+        if(namedTypes.Identifier.check(node.expression.right)){
+          addTypedNode(node, filePath, node.expression.right.name, false);
+          isNodeStored = true;
+        }
+      }
+
     }
 
     if (!isNodeStored) {
@@ -344,6 +355,10 @@ EmberMigrator.prototype.convertFile = function(typedExport){
   var astCode = typedExport.astNodes.map(function(node) { return recast.print(node).code; }).join('\n');
   var code = imports + astCode + '\n';
   code = code.replace(/;;\n+/g, ';\n'); // for some reason recast print will add another semicolon if there is already one
+
+  // for some reason there is a rogue semicolon
+  code = code.replace(/\n;\n/, '\n');
+  
   code = code.replace(new RegExp(this.rootAppName + "\\.", 'g'), '');
   code = code.replace(/Em\./g, 'Ember.');
   // For any module imported that used to be a window global

--- a/lib/migrator-visitor.js
+++ b/lib/migrator-visitor.js
@@ -2,6 +2,7 @@ var recast = require('recast');
 var namedTypes = recast.types.namedTypes;
 var builders = recast.types.builders;
 var Visitor = recast.Visitor;
+var TypedExport = require('./typed-export');
 
 // Helper function to extract global namespace name from a member expression node
 function extractMemberExpressionInfo(node) {
@@ -18,12 +19,15 @@ function extractMemberExpressionInfo(node) {
   return info;
 }
 
+
 // The primary purpose of the process visitor is to find the set of all imports we need
 // to construct the output file
 var MigratorVisitor = Visitor.extend({
   init: function(options) {
     this.rootAppName = options.rootAppName;
+    this.localAppName = options.localAppName;
     this.classesFilepathMap = options.classesFilepathMap;
+    this.outputDirectory = options.outputDirectory;
     // This is what we will construct our import strings from
     this.imports = {};
   },
@@ -82,6 +86,38 @@ var MigratorVisitor = Visitor.extend({
       }
     }
     
+    return node;
+  },
+  visitVariableDeclaration: function(node){
+    var typedExport = TypedExport;
+    // visit the node if the right side of the expression is a call expression
+    // to the require function
+    var declaration = node.declarations[0];
+    if(namedTypes.CallExpression.check(declaration.init) &&
+         declaration.init.callee.name === 'require' &&
+         declaration.init.arguments.length === 1){
+      var className = declaration.id.name,
+        requirePath = declaration.init.arguments[0].raw;
+      var newType = typedExport.determineType(requirePath, className);
+      var fileName = typedExport.filePathForClassname(className, newType, requirePath, [])
+      var instance = new typedExport({
+        type: newType,
+        fileName: fileName,
+        exportName: className,
+        oldFileName: requirePath,
+        appName: this.localAppName,
+        outputDirectory: this.outputDirectory
+      })
+      
+      var exportPath = instance.exportPath(this.rootAppName);
+
+      this.imports[className] = exportPath;
+      var newNode = builders.emptyStatement();
+      this.genericVisit(newNode);
+      return newNode;
+
+    }
+    this.genericVisit(node);
     return node;
   }
 });

--- a/lib/migrator-visitor.js
+++ b/lib/migrator-visitor.js
@@ -64,7 +64,24 @@ var MigratorVisitor = Visitor.extend({
       // Recursively check this node to see if it is a member expression and we need an import
       this.genericVisit(newNode);
       return newNode;
+    }     
+
+    var info = extractMemberExpressionInfo(leftNode);
+    // check to see if the member expressions is modules.exports
+    if(info.namespace === 'module' &&
+       info.property === 'exports') {
+
+      // check if the right side is an identifier and not a direct
+      // export of a function
+      if(namedTypes.Identifier.check(rightNode)){
+
+        // if the export definition is "simple" ie;
+        // module.exports = App;
+        // remove the assignment expression
+        return builders.emptyStatement();
+      }
     }
+    
     return node;
   }
 });

--- a/test/common_js-debug-test.js
+++ b/test/common_js-debug-test.js
@@ -16,15 +16,6 @@ describe('migrating commonjs', function(){
     this.migrator.clean();
   });
 
-  describe('Works with application file', function(){
-    it(migrates('application.js'));
-  });
-
-  describe('Works with controller files', function(){
-    it(migrates('controllers/comment-activity.js'));
-    it(migrates('controllers/preserve-comments.js'));
-  });
-
   describe('Works with controllers with dependencies', function(){
     it(migrates('controllers/with-mixin.js'));
   });

--- a/test/common_js-test.js
+++ b/test/common_js-test.js
@@ -1,0 +1,23 @@
+var assert = require('chai').assert;
+var path = require('path');
+var fs = require('fs');
+var helper = require('./test_helper');
+var migrates = helper.migrates;
+var it = helper.it;
+var fs = require('fs');
+
+describe('migrating models', function(){
+  before(function(){
+    this.migrator = helper.migrator({inputFixtures: 'common_js'});
+    this.migrator.run();
+  });
+
+  after(function(){
+    this.migrator.clean();
+  });
+
+  describe('Works with application file', function(){
+    it(migrates('application.js'));
+  });
+
+});

--- a/test/common_js-test.js
+++ b/test/common_js-test.js
@@ -6,7 +6,7 @@ var migrates = helper.migrates;
 var it = helper.it;
 var fs = require('fs');
 
-describe('migrating models', function(){
+describe('migrating commonjs', function(){
   before(function(){
     this.migrator = helper.migrator({inputFixtures: 'common_js'});
     this.migrator.run();

--- a/test/common_js-test.js
+++ b/test/common_js-test.js
@@ -20,4 +20,9 @@ describe('migrating commonjs', function(){
     it(migrates('application.js'));
   });
 
+  describe('Works with controller files', function(){
+    it(migrates('controllers/comment-activity.js'));
+    it(migrates('controllers/preserve-comments.js'));
+  });
+
 });

--- a/test/fixtures/common_js/input/application.js
+++ b/test/fixtures/common_js/input/application.js
@@ -1,0 +1,7 @@
+var App = Ember.Application.extend({
+  someProperty: function() {
+    console.log('hello App');
+  }
+});
+
+module.exports = App;

--- a/test/fixtures/common_js/input/controllers/comment_activity.js
+++ b/test/fixtures/common_js/input/controllers/comment_activity.js
@@ -1,0 +1,5 @@
+var CommentActivityController = Ember.ObjectController.extend({
+  someControllerProperty: 'props'
+});
+
+module.exports = CommentActivityController;

--- a/test/fixtures/common_js/input/controllers/preserve_comments.js
+++ b/test/fixtures/common_js/input/controllers/preserve_comments.js
@@ -1,0 +1,15 @@
+/* Some global block
+ * comment on multiple lines.
+ */
+
+// A global comment
+var PreserveCommentsController = Ember.ObjectController.extend({
+  // A comment on a property
+  someControllerProperty: 'props',
+  aMethod: function() {
+    // A comment within a method
+    console.log('hello');
+  }
+});
+
+module.exports = PreserveCommentsController;

--- a/test/fixtures/common_js/input/controllers/with_mixin.js
+++ b/test/fixtures/common_js/input/controllers/with_mixin.js
@@ -1,0 +1,7 @@
+var UsefulMixin = require("../mixins/useful_mixin");
+
+var WithMixinController = Ember.ObjectController.extend(UsefulMixin, {
+  someControllerProperty: 'props'
+});
+
+module.exports = WithMixinController;

--- a/test/fixtures/common_js/output/application.js
+++ b/test/fixtures/common_js/output/application.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+var App = Ember.Application.extend({
+  someProperty: function() {
+    console.log('hello App');
+  }
+});
+
+export default App;

--- a/test/fixtures/common_js/output/controllers/comment-activity.js
+++ b/test/fixtures/common_js/output/controllers/comment-activity.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+var CommentActivityController = Ember.ObjectController.extend({
+  someControllerProperty: 'props'
+});
+
+export default CommentActivityController;

--- a/test/fixtures/common_js/output/controllers/preserve-comments.js
+++ b/test/fixtures/common_js/output/controllers/preserve-comments.js
@@ -1,0 +1,17 @@
+import Ember from 'ember';
+
+/* Some global block
+ * comment on multiple lines.
+ */
+
+// A global comment
+var PreserveCommentsController = Ember.ObjectController.extend({
+  // A comment on a property
+  someControllerProperty: 'props',
+  aMethod: function() {
+    // A comment within a method
+    console.log('hello');
+  }
+});
+
+export default PreserveCommentsController;

--- a/test/fixtures/common_js/output/controllers/with-mixin.js
+++ b/test/fixtures/common_js/output/controllers/with-mixin.js
@@ -1,0 +1,9 @@
+import UsefulMixin from '/my-app/mixins/useful';
+import Ember from 'ember';
+
+
+var WithMixinController = Ember.ObjectController.extend(UsefulMixin, {
+  someControllerProperty: 'props'
+});
+
+export default WithMixinController;


### PR DESCRIPTION
Adds a check for the commonjs export syntax and
uses that to declare the name of es6 export

 - first basic test passing

closes #51 when merged

:warning: not ready for pull in yet :warning: 

@fivetanley looking to get some early feedback on this as soon as you can

Thanks!