### PR TITLE
A more conical application.js file test.

### DIFF
--- a/lib/migrator-visitor.js
+++ b/lib/migrator-visitor.js
@@ -77,7 +77,7 @@ var MigratorVisitorPrototype = {
 
     var info = {};
 
-    if (leftNode) {
+    if (leftNode && leftNode.object ) {
       var __namespace__ = leftNode.object.object && leftNode.object.object.name;
       __namespace__ = __namespace__ || leftNode.object.name;
       info = {

--- a/test/ember-rails-test.js
+++ b/test/ember-rails-test.js
@@ -1,0 +1,23 @@
+var assert = require('chai').assert;
+var path = require('path');
+var fs = require('fs');
+var helper = require('./test_helper');
+var migrates = helper.migrates;
+var it = helper.it;
+var fs = require('fs');
+
+describe('migrating ember-rails', function(){
+  before(function(){
+    this.migrator = helper.migrator({inputFixtures: 'ember-rails'});
+    this.migrator.run();
+  });
+
+  after(function(){
+    this.migrator.clean();
+  });
+
+  describe('Works with application file', function(){
+    it(migrates('application.js'));
+  });
+
+});

--- a/test/ember-rails-test.js
+++ b/test/ember-rails-test.js
@@ -8,7 +8,10 @@ var fs = require('fs');
 
 describe('migrating ember-rails', function(){
   before(function(){
-    this.migrator = helper.migrator({inputFixtures: 'ember-rails'});
+    this.migrator = helper.migrator({
+      inputFixtures: 'ember-rails',
+      rootAppName: 'Pos'
+    });
     this.migrator.run();
   });
 

--- a/test/fixtures/ember-rails/input/application.js
+++ b/test/fixtures/ember-rails/input/application.js
@@ -1,0 +1,28 @@
+// This is a manifest file that'll be compiled into application.js, which will include all the files
+// listed below.
+//
+// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
+// or vendor/assets/javascripts of plugins, if any, can be referenced here using a relative path.
+//
+// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
+// the compiled file.
+//
+// WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
+// GO AFTER THE REQUIRES BELOW.
+//
+//= require jquery
+//= require jquery_ujs
+//= require foundation
+//= require handlebars
+//= require ember
+//= require ember-data
+//= require_self
+//= require pos
+
+App = Ember.Application.create({
+  LOG_ACTIVE_GENERATION: true,
+  LOG_MODULE_RESOLVER: true,
+  LOG_TRANSITIONS: true,
+  LOG_TRANSITIONS_INTERNAL: true,
+  LOG_VIEW_LOOKUPS: true,
+});

--- a/test/fixtures/ember-rails/input/application.js
+++ b/test/fixtures/ember-rails/input/application.js
@@ -1,25 +1,12 @@
-// This is a manifest file that'll be compiled into application.js, which will include all the files
-// listed below.
-//
-// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
-// or vendor/assets/javascripts of plugins, if any, can be referenced here using a relative path.
-//
-// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
-// the compiled file.
-//
-// WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
-// GO AFTER THE REQUIRES BELOW.
-//
 //= require jquery
 //= require jquery_ujs
-//= require foundation
 //= require handlebars
 //= require ember
 //= require ember-data
 //= require_self
 //= require pos
 
-App = Ember.Application.create({
+Pos = Ember.Application.create({
   LOG_ACTIVE_GENERATION: true,
   LOG_MODULE_RESOLVER: true,
   LOG_TRANSITIONS: true,

--- a/test/fixtures/ember-rails/output/application.js
+++ b/test/fixtures/ember-rails/output/application.js
@@ -1,0 +1,32 @@
+import Ember from 'ember';
+
+// This is a manifest file that'll be compiled into application.js, which will include all the files
+// listed below.
+//
+// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
+// or vendor/assets/javascripts of plugins, if any, can be referenced here using a relative path.
+//
+// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
+// the compiled file.
+//
+// WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
+// GO AFTER THE REQUIRES BELOW.
+//
+//= require jquery
+//= require jquery_ujs
+//= require foundation
+//= require handlebars
+//= require ember
+//= require ember-data
+//= require_self
+//= require pos
+
+var App = Ember.Application.create({
+  LOG_ACTIVE_GENERATION: true,
+  LOG_MODULE_RESOLVER: true,
+  LOG_TRANSITIONS: true,
+  LOG_TRANSITIONS_INTERNAL: true,
+  LOG_VIEW_LOOKUPS: true,
+});
+
+export default App;

--- a/test/fixtures/ember-rails/output/application.js
+++ b/test/fixtures/ember-rails/output/application.js
@@ -1,27 +1,14 @@
 import Ember from 'ember';
 
-// This is a manifest file that'll be compiled into application.js, which will include all the files
-// listed below.
-//
-// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
-// or vendor/assets/javascripts of plugins, if any, can be referenced here using a relative path.
-//
-// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
-// the compiled file.
-//
-// WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
-// GO AFTER THE REQUIRES BELOW.
-//
 //= require jquery
 //= require jquery_ujs
-//= require foundation
 //= require handlebars
 //= require ember
 //= require ember-data
 //= require_self
 //= require pos
 
-var App = Ember.Application.create({
+Pos = Ember.Application.create({
   LOG_ACTIVE_GENERATION: true,
   LOG_MODULE_RESOLVER: true,
   LOG_TRANSITIONS: true,
@@ -29,4 +16,4 @@ var App = Ember.Application.create({
   LOG_VIEW_LOOKUPS: true,
 });
 
-export default App;
+export default undefined;


### PR DESCRIPTION
This fixes #56 

in the test current `application.js` test uses:
```js
window.App = Ember.Application.extend({});
```

Ember Rails and the Yeoman generate sets up the `application.js` file like this:
```js
App = Ember.Application.create({});
```
The the application.js file without the `window.App` namespace will be migrated to this. 

```js
import Ember from 'ember';
Pos = Ember.Application.create({
});
export default undefined;
```
Once you create the ember-cli app by runing `ember init` after the migration the `application.js` file is no longer needed. Here is the workflow I suggest for migrating their apps. 

1. run `find javascripts -name '.gitkeep' -delete` to delete any .gitkeep files
2. run the `ember-cli-migrator` over your global ember app
3. run `ember init` in the folder containing the `app` folder
4. move/delete any `js` files that might be out of place in your app.

The last step would include deleting the `application.js` file. 

At some point we could move all `.js` files not recognized by the migrator to an `unknown-javascripts` folder during the processing phase.

I would love to hear you feedback.
