### PR TITLE
Export App.Type as app/type/basic

### DIFF
--- a/lib/typed-export.js
+++ b/lib/typed-export.js
@@ -93,6 +93,13 @@ TypedExport.convertToOutputFilename = function(stringInput) {
 
 TypedExport.filePathForClassname = function(className, type, filePath, exportFiles) {
   var newFilePath;
+
+  // Check for "App.Type" case, in Globals, Ember would use App.Type instead of Ember.Type for automatically
+  // generated classes. In modules land, Ember looks for /app/type/basic instead.
+  if (className && className.toLowerCase() === type) {
+    className = "basic";
+  }
+
   if (type === 'unknown') {
     newFilePath = filePath;
   } else {

--- a/test/fixtures/vanilla/input/routes/basic_and_foo_route.js
+++ b/test/fixtures/vanilla/input/routes/basic_and_foo_route.js
@@ -1,0 +1,2 @@
+App.Route = Ember.Route.extend({});
+App.FooRoute = App.Route.extend({});

--- a/test/fixtures/vanilla/output/routes/basic.js
+++ b/test/fixtures/vanilla/output/routes/basic.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+var Route = Ember.Route.extend({});
+
+export default Route;

--- a/test/fixtures/vanilla/output/routes/foo.js
+++ b/test/fixtures/vanilla/output/routes/foo.js
@@ -1,0 +1,5 @@
+import Route from 'my-app/routes/basic';
+
+var FooRoute = Route.extend({});
+
+export default FooRoute;

--- a/test/models-test.js
+++ b/test/models-test.js
@@ -141,4 +141,9 @@ describe('migrating models', function(){
     it(migrates('controllers/with-mixin.js'));
   });
 
+  describe("Migrates App.Route to routes/basic. Imports routes/basic correctly ", function(){
+    it(migrates('routes/basic.js'));
+    it(migrates('routes/foo.js'));
+  });
+
 });


### PR DESCRIPTION
Took me a while, but closes #63.

Will migrate App.Type as /app/type/basic. Supports creating default Route/Controller/View/Whatever classes that Ember will use when auto generating classes.
