### PR TITLE
Add options to force git mv and to ignore some source directories

### DIFF
--- a/bin/ember-cli-migrator
+++ b/bin/ember-cli-migrator
@@ -15,6 +15,7 @@ program
   .option('-a, --ember-cli-app-name [name]', 'Name of application namespace/modulePrefix. This is the name of the app you would pass to `ember new <ember-cli-app-name>`')
   .option('-s, --source [source_directory]', 'Directory to perform migration on')
   .option('-t, --target [target_directory]',  'Directory to output result of migration')
+  .option('-f, --force', 'Migrate even if output files exist')
   .parse(process.argv);
 
 var curDir = './';
@@ -23,6 +24,7 @@ var tmpDir = path.join(curDir, "/tmp");
 var migrator = new EmberMigrator({
   inputDirectory: program.source || curDir,
   outputDirectory: program.target || tmpDir,
+  forceOutput: program.force,
   appName: program.emberCliAppName,
   rootAppName: program.global
 });

--- a/bin/ember-cli-migrator
+++ b/bin/ember-cli-migrator
@@ -16,6 +16,7 @@ program
   .option('-s, --source [source_directory]', 'Directory to perform migration on')
   .option('-t, --target [target_directory]',  'Directory to output result of migration')
   .option('-f, --force', 'Migrate even if output files exist')
+  .option('--ignore-subdirs [comma_separated_dirs]', 'Sub-directories in source to ignore')
   .parse(process.argv);
 
 var curDir = './';
@@ -25,6 +26,7 @@ var migrator = new EmberMigrator({
   inputDirectory: program.source || curDir,
   outputDirectory: program.target || tmpDir,
   forceOutput: program.force,
+  ignoreDirs: program.ignoreSubdirs,
   appName: program.emberCliAppName,
   rootAppName: program.global
 });

--- a/lib/ember-migrator.js
+++ b/lib/ember-migrator.js
@@ -22,6 +22,8 @@ function EmberMigrator(options){
   this.inputDirectory = options.inputDirectory;
   // Where we will place the ember-cli app
   this.outputDirectory  = options.outputDirectory + '/app';
+  // If git mv is forced
+  this.gitMv = options.forceOutput ? "git mv -f " : "git mv ";
   // Global app name used in input files
   this.rootAppName = options.rootAppName || 'App';
   // Our ember-cli app name
@@ -90,7 +92,7 @@ EmberMigrator.prototype.run = function EmberMigrator_run(){
 
       if (outputPath !== file.oldFileName && !this.testing) {
         this.writeLine(chalk.green('Git Move') + ' Moving ' + file.oldFileName + ' to ' + outputPath);
-        execSync("git mv " + file.oldFileName + " " + outputPath);
+        execSync(this.gitMv + file.oldFileName + " " + outputPath);
       }
     }
   }, this);
@@ -115,7 +117,7 @@ EmberMigrator.prototype.run = function EmberMigrator_run(){
     else if (!this.testing) {
       this.writeLine(chalk.green('Git Move') + ' Moving ' + filePath + ' to ' + outputFile);
       mkdirp.sync(outputFolder);
-      execSync("git mv " + fullPath + " " + outputFile);
+      execSync(this.gitMv + fullPath + " " + outputFile);
     }
   }, this);
 
@@ -129,7 +131,7 @@ EmberMigrator.prototype.run = function EmberMigrator_run(){
       outputFile = path.join(self.outputDirectory, string.dasherize(filePath));
       if (fullPath !== outputFile) {
         this.writeLine(chalk.green('No Change or Move') + ' ' + fullPath);
-        execSync("git mv " + fullPath + " " + outputFile);
+        execSync(this.gitMv + fullPath + " " + outputFile);
         return;
       }
     } else {

--- a/lib/ember-migrator.js
+++ b/lib/ember-migrator.js
@@ -24,6 +24,8 @@ function EmberMigrator(options){
   this.outputDirectory  = options.outputDirectory + '/app';
   // If git mv is forced
   this.gitMv = options.forceOutput ? "git mv -f " : "git mv ";
+  // Ignore directories
+  this.ignoreDirs = options.ignoreDirs ? options.ignoreDirs.split(',') : [];
   // Global app name used in input files
   this.rootAppName = options.rootAppName || 'App';
   // Our ember-cli app name
@@ -64,7 +66,15 @@ EmberMigrator.prototype.run = function EmberMigrator_run(){
     var isDir = fs.lstatSync(fullPath).isDirectory();
     var isJS = string.endsWith(file, '.js');
     var isHbs = string.endsWith(file, '.handlebars') || string.endsWith(file, '.hbs');
-    if (!isDir) {
+    var subDir = file.substring(0, file.lastIndexOf(path.sep) + 1);
+    var isIgnoreDir = false;
+    self.ignoreDirs.forEach(function (directory) {
+      directory = directory + path.sep;
+      if (subDir && subDir.substring(0, directory.length) === directory) {
+        isIgnoreDir = true;
+      }
+    });
+    if (!isDir && !isIgnoreDir) {
       if (isJS) {
         jsFiles.push(file);
       } else if (isHbs) {


### PR DESCRIPTION
To support an incremental approach to migration, we needed the two options: -f for git mv, and ability to ignore directores.

It's still not meeting our requirement fully -- we don't want to delete the source files. At least, not via the migrator. The idea is to run the migrator from time to time and be able to test and bring up the ember-cli version. While keeping the original EmberAppKit project shipping until final cutover.