### PR TITLE
Specify `sudo: false` for Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+sudo: false
 node_js:
   - "0.12"
   - "iojs"


### PR DESCRIPTION
To migrate from legacy to container-based infrastructure.
ref: http://docs.travis-ci.com/user/migrating-from-legacy/