### PR TITLE
Upgrade recast

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,7500 @@
+{
+  "name": "ember-cli-migrator",
+  "version": "0.10.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "accepts": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
+      "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+      "requires": {
+        "mime-types": "2.1.17",
+        "negotiator": "0.6.1"
+      }
+    },
+    "acorn": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+      "integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ="
+    },
+    "after": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+    },
+    "ansi": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+      "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "ansicolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
+    },
+    "anymatch": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "requires": {
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
+      }
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "requires": {
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "requires": {
+        "sprintf-js": "1.0.3"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+        }
+      }
+    },
+    "arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "requires": {
+        "arr-flatten": "1.1.0"
+      }
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+    },
+    "arraybuffer.slice": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+      "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco="
+    },
+    "assertion-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
+      "integrity": "sha1-x/hUOP3UZrx8oWq5DIFRN5el0js=",
+      "dev": true
+    },
+    "ast-types": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.10.1.tgz",
+      "integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ=="
+    },
+    "async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+    },
+    "backbone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.3.3.tgz",
+      "integrity": "sha1-TMgOp8sWMaxHSInOQPL4vGg7KZk=",
+      "requires": {
+        "underscore": "1.8.3"
+      }
+    },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base64-arraybuffer": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+    },
+    "base64id": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
+      "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
+    },
+    "better-assert": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+      "requires": {
+        "callsite": "1.0.0"
+      }
+    },
+    "blob": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
+    },
+    "body-parser": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "1.0.4",
+        "debug": "2.6.9",
+        "depd": "1.1.1",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "on-finished": "2.3.0",
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
+        "type-is": "1.6.15"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "requires": {
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
+      }
+    },
+    "broccoli-caching-writer": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-0.5.5.tgz",
+      "integrity": "sha1-6Ma1s8o+zZQHhPuXBHb7KYBesVg=",
+      "requires": {
+        "broccoli-kitchen-sink-helpers": "0.2.6",
+        "core-object": "0.0.3",
+        "debug": "2.6.9",
+        "lodash-node": "2.4.1",
+        "promise-map-series": "0.2.3",
+        "quick-temp": "0.1.8",
+        "rimraf": "2.6.2",
+        "rsvp": "3.6.2",
+        "symlink-or-copy": "1.1.8"
+      },
+      "dependencies": {
+        "core-object": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/core-object/-/core-object-0.0.3.tgz",
+          "integrity": "sha1-VQghWYslijOowiY6+gcrDfUpUyE=",
+          "requires": {
+            "lodash-node": "2.4.1"
+          }
+        }
+      }
+    },
+    "broccoli-es3-safe-recast": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/broccoli-es3-safe-recast/-/broccoli-es3-safe-recast-2.0.0.tgz",
+      "integrity": "sha1-yx0YB98D/TbfvDWtCc1sqmOxf4k=",
+      "requires": {
+        "broccoli-filter": "0.1.12",
+        "es3-safe-recast": "2.0.2"
+      }
+    },
+    "broccoli-es6modules": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/broccoli-es6modules/-/broccoli-es6modules-0.6.1.tgz",
+      "integrity": "sha1-z6q6h7p1dcbbtlqjT7yNElqabqg=",
+      "requires": {
+        "broccoli-caching-writer": "0.5.3",
+        "broccoli-kitchen-sink-helpers": "0.2.9",
+        "esperanto": "0.6.34",
+        "mkdirp": "0.5.1",
+        "rsvp": "3.6.2",
+        "walk-sync": "0.1.3"
+      },
+      "dependencies": {
+        "broccoli-caching-writer": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-0.5.3.tgz",
+          "integrity": "sha1-S6IIofD6y9KURm3VqJ0QeXGTPyY=",
+          "requires": {
+            "broccoli-kitchen-sink-helpers": "0.2.9",
+            "core-object": "0.0.2",
+            "promise-map-series": "0.2.3",
+            "quick-temp": "0.1.8",
+            "rimraf": "2.6.2",
+            "rsvp": "3.6.2",
+            "symlink-or-copy": "1.1.8"
+          }
+        },
+        "broccoli-kitchen-sink-helpers": {
+          "version": "0.2.9",
+          "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+          "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
+          "requires": {
+            "glob": "5.0.15",
+            "mkdirp": "0.5.1"
+          }
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
+    "broccoli-filter": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/broccoli-filter/-/broccoli-filter-0.1.12.tgz",
+      "integrity": "sha1-qROF/ml+s+tx54E//ZIEw8GD9Y8=",
+      "requires": {
+        "broccoli-kitchen-sink-helpers": "0.2.6",
+        "broccoli-writer": "0.1.1",
+        "mkdirp": "0.3.5",
+        "promise-map-series": "0.2.3",
+        "quick-temp": "0.1.8",
+        "rsvp": "3.6.2",
+        "walk-sync": "0.1.3"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.3.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
+        }
+      }
+    },
+    "broccoli-funnel": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-0.2.2.tgz",
+      "integrity": "sha1-6o5S/BNMztQskFpR+hRULnt1Pfg=",
+      "requires": {
+        "core-object": "0.0.2",
+        "minimatch": "2.0.10",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "rsvp": "3.6.2",
+        "symlink-or-copy": "1.1.8",
+        "walk-sync": "0.1.3"
+      }
+    },
+    "broccoli-kitchen-sink-helpers": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.6.tgz",
+      "integrity": "sha1-RKYQ+2AAR9YnqUmh87CgQn7TYQo=",
+      "requires": {
+        "glob": "4.0.4",
+        "mkdirp": "0.3.5"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.4.tgz",
+          "integrity": "sha1-cwzgGQ2H7KeBI5gBjiG+cStNadI=",
+          "requires": {
+            "graceful-fs": "3.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "0.3.0",
+            "once": "1.4.0"
+          }
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.3.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
+        }
+      }
+    },
+    "broccoli-merge-trees": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-0.2.1.tgz",
+      "integrity": "sha1-iVO/n4hq6toN7A66r7glHvU+zyc=",
+      "requires": {
+        "broccoli-writer": "0.1.1",
+        "promise-map-series": "0.2.3",
+        "symlink-or-copy": "1.1.8"
+      }
+    },
+    "broccoli-sane-watcher": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/broccoli-sane-watcher/-/broccoli-sane-watcher-1.1.5.tgz",
+      "integrity": "sha1-8rCvnPCvt0x6Sc2I6xHGhp7owMA=",
+      "requires": {
+        "broccoli-slow-trees": "1.1.0",
+        "debug": "2.6.9",
+        "rsvp": "3.6.2",
+        "sane": "1.7.0"
+      }
+    },
+    "broccoli-slow-trees": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/broccoli-slow-trees/-/broccoli-slow-trees-1.1.0.tgz",
+      "integrity": "sha1-QmxXJOAIEH5Fc/c+ipynApFrePc="
+    },
+    "broccoli-sourcemap-concat": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/broccoli-sourcemap-concat/-/broccoli-sourcemap-concat-0.4.4.tgz",
+      "integrity": "sha1-yrbox8oKgDP7KMuBHfr0OhclRGY=",
+      "requires": {
+        "broccoli-caching-writer": "0.5.3",
+        "broccoli-kitchen-sink-helpers": "0.2.6",
+        "broccoli-writer": "0.1.1",
+        "combined-stream": "0.0.7",
+        "fast-sourcemap-concat": "0.2.7",
+        "lodash-node": "2.4.1",
+        "mkdirp": "0.5.1",
+        "rsvp": "3.6.2"
+      },
+      "dependencies": {
+        "broccoli-caching-writer": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-0.5.3.tgz",
+          "integrity": "sha1-S6IIofD6y9KURm3VqJ0QeXGTPyY=",
+          "requires": {
+            "broccoli-kitchen-sink-helpers": "0.2.6",
+            "core-object": "0.0.2",
+            "promise-map-series": "0.2.3",
+            "quick-temp": "0.1.8",
+            "rimraf": "2.6.2",
+            "rsvp": "3.6.2",
+            "symlink-or-copy": "1.1.8"
+          }
+        }
+      }
+    },
+    "broccoli-unwatched-tree": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/broccoli-unwatched-tree/-/broccoli-unwatched-tree-0.1.1.tgz",
+      "integrity": "sha1-QxL94Eva/megWpZ9csxQsYSp9RQ="
+    },
+    "broccoli-writer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/broccoli-writer/-/broccoli-writer-0.1.1.tgz",
+      "integrity": "sha1-1NcaqPKvvGejhmuRotp5CEuWqy0=",
+      "requires": {
+        "quick-temp": "0.1.8",
+        "rsvp": "3.6.2"
+      }
+    },
+    "bser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+      "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+      "requires": {
+        "node-int64": "0.4.0"
+      }
+    },
+    "buffer-equal": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.2.tgz",
+      "integrity": "sha1-7Lt5D1aNQAmKYkK1SAXHWAXrk48="
+    },
+    "bunker": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
+      "integrity": "sha1-yImSRkqOKm7ehpMDdfkrWAd++Xw=",
+      "requires": {
+        "burrito": "0.2.12"
+      }
+    },
+    "burrito": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
+      "integrity": "sha1-0NbmrIHV6ZeJxvpKzLCwAx6lT2s=",
+      "requires": {
+        "traverse": "0.5.2",
+        "uglify-js": "1.1.1"
+      },
+      "dependencies": {
+        "traverse": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz",
+          "integrity": "sha1-4gPFjV9/DjfbbnTArLkpuwm2HYU="
+        }
+      }
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+    },
+    "callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
+    },
+    "cardinal": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.5.0.tgz",
+      "integrity": "sha1-ANX2YdvUqr/ffUHOSKWlm8o1opE=",
+      "requires": {
+        "ansicolors": "0.2.1",
+        "redeyed": "0.5.0"
+      }
+    },
+    "chai": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
+      "integrity": "sha1-5AMcyHZURhp1lD5aNatG6vOcHrk=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.0",
+        "deep-eql": "0.1.3"
+      }
+    },
+    "chai-as-promised": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-4.3.0.tgz",
+      "integrity": "sha1-D6hhsLMb/mhn9edw8Ph3vmDs5e4=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "charm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/charm/-/charm-1.0.2.tgz",
+      "integrity": "sha1-it02cVOm2aWBMxBSxAkJkdqZXjU=",
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "cli-table": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+      "requires": {
+        "colors": "1.0.3"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+    },
+    "combined-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+      "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+      "requires": {
+        "delayed-stream": "0.0.5"
+      }
+    },
+    "commander": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
+    },
+    "component-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
+    },
+    "component-emitter": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+      "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM="
+    },
+    "component-inherit": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
+    },
+    "compressible": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
+      "integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=",
+      "requires": {
+        "mime-db": "1.30.0"
+      }
+    },
+    "compression": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz",
+      "integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
+      "requires": {
+        "accepts": "1.3.4",
+        "bytes": "3.0.0",
+        "compressible": "2.0.12",
+        "debug": "2.6.9",
+        "on-headers": "1.0.1",
+        "safe-buffer": "5.1.1",
+        "vary": "1.1.2"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
+    "consolidate": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.12.1.tgz",
+      "integrity": "sha1-H/AJ58jQPB9sBQV01GS5L9DPx9U="
+    },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "core-object": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/core-object/-/core-object-0.0.2.tgz",
+      "integrity": "sha1-yab+6PcS4oH6n2+6ECQ0Ceot68M=",
+      "requires": {
+        "lodash-node": "2.4.1"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cpr": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/cpr/-/cpr-0.4.3.tgz",
+      "integrity": "sha1-CiPktuwj87jMekBey1z9x3j33iU=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.4.5"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+        },
+        "rimraf": {
+          "version": "2.4.5",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+          "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+          "requires": {
+            "glob": "6.0.4"
+          }
+        }
+      }
+    },
+    "cross-spawn": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.9.tgz",
+      "integrity": "sha1-vWf5bAfvtjA7f+lMHpefiEeOCjk=",
+      "requires": {
+        "lru-cache": "2.7.3"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
+    "delayed-stream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+      "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8="
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "depd": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "did_it_work": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/did_it_work/-/did_it_work-0.0.6.tgz",
+      "integrity": "sha1-UYDLnhbr+ah1OgzGtK+czf9x7AU="
+    },
+    "diff": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
+      "integrity": "sha1-NDJ2MI7Jkbe8giZ+1VvBQR+XFmY=",
+      "dev": true
+    },
+    "difflet": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
+      "integrity": "sha1-qyOzH1ZJtvqo49KsvTNEZzZcpvo=",
+      "requires": {
+        "charm": "0.1.2",
+        "deep-is": "0.1.3",
+        "traverse": "0.6.6"
+      },
+      "dependencies": {
+        "charm": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
+          "integrity": "sha1-BsIe7RobBq62dVPNxT4jJ0usIpY="
+        }
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "ember-cli": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-0.2.7.tgz",
+      "integrity": "sha1-/vzZ/n+vJ2paaMi/zJIojA8GeNU=",
+      "requires": {
+        "abbrev": "1.1.1",
+        "bower": "1.4.1",
+        "bower-config": "0.5.2",
+        "broccoli": "0.15.4",
+        "broccoli-caching-writer": "0.5.5",
+        "broccoli-clean-css": "0.2.0",
+        "broccoli-es3-safe-recast": "2.0.0",
+        "broccoli-es6modules": "0.6.1",
+        "broccoli-filter": "0.1.12",
+        "broccoli-funnel": "0.2.2",
+        "broccoli-kitchen-sink-helpers": "0.2.6",
+        "broccoli-merge-trees": "0.2.1",
+        "broccoli-sane-watcher": "1.1.5",
+        "broccoli-sourcemap-concat": "0.4.4",
+        "broccoli-unwatched-tree": "0.1.1",
+        "broccoli-writer": "0.1.1",
+        "chalk": "1.0.0",
+        "compression": "1.7.1",
+        "concat-stream": "1.4.8",
+        "configstore": "0.3.2",
+        "core-object": "0.0.2",
+        "cpr": "0.4.3",
+        "debug": "2.6.9",
+        "diff": "1.4.0",
+        "ember-cli-copy-dereference": "1.0.0",
+        "ember-router-generator": "1.2.3",
+        "escape-string-regexp": "1.0.5",
+        "exit": "0.1.2",
+        "express": "4.12.4",
+        "findup": "0.1.5",
+        "fs-extra": "0.16.5",
+        "git-repo-info": "1.1.1",
+        "github": "0.2.4",
+        "glob": "5.0.3",
+        "http-proxy": "1.16.2",
+        "inflection": "1.7.1",
+        "inquirer": "0.5.1",
+        "is-git-url": "0.2.3",
+        "isbinaryfile": "2.0.4",
+        "js-string-escape": "1.0.1",
+        "leek": "0.0.18",
+        "lodash": "3.9.3",
+        "markdown-it": "4.0.3",
+        "markdown-it-terminal": "0.0.2",
+        "minimatch": "2.0.8",
+        "morgan": "1.5.3",
+        "node-uuid": "1.4.3",
+        "nopt": "3.0.2",
+        "npm": "2.11.0",
+        "pleasant-progress": "1.1.0",
+        "promise-map-series": "0.2.3",
+        "proxy-middleware": "0.11.0",
+        "quick-temp": "0.1.2",
+        "readline2": "0.1.1",
+        "resolve": "1.1.6",
+        "rimraf": "2.3.2",
+        "rsvp": "3.6.2",
+        "sane": "1.7.0",
+        "semver": "4.3.6",
+        "strip-ansi": "2.0.1",
+        "symlink-or-copy": "1.1.8",
+        "temp": "0.8.1",
+        "testem": "0.8.5",
+        "through": "2.3.7",
+        "tiny-lr": "0.1.5",
+        "walk-sync": "0.1.3",
+        "yam": "0.0.18"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+          "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0="
+        },
+        "bower": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "archy": "1.0.0",
+            "bower-config": "0.6.1",
+            "bower-endpoint-parser": "0.2.2",
+            "bower-json": "0.4.0",
+            "bower-logger": "0.2.2",
+            "bower-registry-client": "0.3.0",
+            "cardinal": "0.4.4",
+            "chalk": "1.0.0",
+            "chmodr": "0.1.0",
+            "configstore": "0.3.2",
+            "decompress-zip": "0.1.0",
+            "fstream": "1.0.6",
+            "fstream-ignore": "1.0.2",
+            "github": "0.2.4",
+            "glob": "4.5.3",
+            "graceful-fs": "3.0.8",
+            "handlebars": "2.0.0",
+            "inquirer": "0.8.0",
+            "insight": "0.5.3",
+            "is-root": "1.0.0",
+            "junk": "1.0.1",
+            "lockfile": "1.0.1",
+            "lru-cache": "2.6.4",
+            "mkdirp": "0.5.0",
+            "mout": "0.11.0",
+            "nopt": "3.0.2",
+            "opn": "1.0.2",
+            "p-throttler": "0.1.1",
+            "promptly": "0.2.0",
+            "q": "1.4.1",
+            "request": "2.53.0",
+            "request-progress": "0.3.1",
+            "retry": "0.6.1",
+            "rimraf": "2.3.2",
+            "semver": "2.3.2",
+            "shell-quote": "1.4.3",
+            "stringify-object": "1.0.1",
+            "tar-fs": "1.5.1",
+            "tmp": "0.0.24",
+            "update-notifier": "0.3.2",
+            "user-home": "1.1.1",
+            "which": "1.1.1"
+          },
+          "dependencies": {
+            "archy": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "bower-config": {
+              "version": "0.6.1",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "2.0.3",
+                "mout": "0.9.1",
+                "optimist": "0.6.1",
+                "osenv": "0.0.3"
+              },
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "2.0.3",
+                  "bundled": true
+                },
+                "mout": {
+                  "version": "0.9.1",
+                  "bundled": true
+                },
+                "optimist": {
+                  "version": "0.6.1",
+                  "bundled": true,
+                  "requires": {
+                    "minimist": "0.0.10",
+                    "wordwrap": "0.0.3"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.10",
+                      "bundled": true
+                    },
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "bundled": true
+                    }
+                  }
+                },
+                "osenv": {
+                  "version": "0.0.3",
+                  "bundled": true
+                }
+              }
+            },
+            "bower-endpoint-parser": {
+              "version": "0.2.2",
+              "bundled": true
+            },
+            "bower-json": {
+              "version": "0.4.0",
+              "bundled": true,
+              "requires": {
+                "deep-extend": "0.2.11",
+                "graceful-fs": "2.0.3",
+                "intersect": "0.0.3"
+              },
+              "dependencies": {
+                "deep-extend": {
+                  "version": "0.2.11",
+                  "bundled": true
+                },
+                "graceful-fs": {
+                  "version": "2.0.3",
+                  "bundled": true
+                },
+                "intersect": {
+                  "version": "0.0.3",
+                  "bundled": true
+                }
+              }
+            },
+            "bower-logger": {
+              "version": "0.2.2",
+              "bundled": true
+            },
+            "bower-registry-client": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "async": "0.2.10",
+                "bower-config": "0.6.1",
+                "graceful-fs": "2.0.3",
+                "lru-cache": "2.3.1",
+                "mkdirp": "0.3.5",
+                "request": "2.51.0",
+                "request-replay": "0.2.0",
+                "rimraf": "2.2.8"
+              },
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "bundled": true
+                },
+                "graceful-fs": {
+                  "version": "2.0.3",
+                  "bundled": true
+                },
+                "lru-cache": {
+                  "version": "2.3.1",
+                  "bundled": true
+                },
+                "mkdirp": {
+                  "version": "0.3.5",
+                  "bundled": true
+                },
+                "request": {
+                  "version": "2.51.0",
+                  "bundled": true,
+                  "requires": {
+                    "aws-sign2": "0.5.0",
+                    "bl": "0.9.4",
+                    "caseless": "0.8.0",
+                    "combined-stream": "0.0.7",
+                    "forever-agent": "0.5.2",
+                    "form-data": "0.2.0",
+                    "hawk": "1.1.1",
+                    "http-signature": "0.10.1",
+                    "json-stringify-safe": "5.0.1",
+                    "mime-types": "1.0.2",
+                    "node-uuid": "1.4.3",
+                    "oauth-sign": "0.5.0",
+                    "qs": "2.3.3",
+                    "stringstream": "0.0.4",
+                    "tough-cookie": "1.2.0",
+                    "tunnel-agent": "0.4.0"
+                  },
+                  "dependencies": {
+                    "aws-sign2": {
+                      "version": "0.5.0",
+                      "bundled": true
+                    },
+                    "bl": {
+                      "version": "0.9.4",
+                      "bundled": true,
+                      "requires": {
+                        "readable-stream": "1.0.33"
+                      },
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "1.0.33",
+                          "bundled": true,
+                          "requires": {
+                            "core-util-is": "1.0.1",
+                            "inherits": "2.0.1",
+                            "isarray": "0.0.1",
+                            "string_decoder": "0.10.31"
+                          },
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "bundled": true
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "bundled": true
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "bundled": true
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "caseless": {
+                      "version": "0.8.0",
+                      "bundled": true
+                    },
+                    "combined-stream": {
+                      "version": "0.0.7",
+                      "bundled": true,
+                      "requires": {
+                        "delayed-stream": "0.0.5"
+                      },
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "forever-agent": {
+                      "version": "0.5.2",
+                      "bundled": true
+                    },
+                    "form-data": {
+                      "version": "0.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "async": "0.9.2",
+                        "combined-stream": "0.0.7",
+                        "mime-types": "2.0.13"
+                      },
+                      "dependencies": {
+                        "async": {
+                          "version": "0.9.2",
+                          "bundled": true
+                        },
+                        "mime-types": {
+                          "version": "2.0.13",
+                          "bundled": true,
+                          "requires": {
+                            "mime-db": "1.11.0"
+                          },
+                          "dependencies": {
+                            "mime-db": {
+                              "version": "1.11.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "hawk": {
+                      "version": "1.1.1",
+                      "bundled": true,
+                      "requires": {
+                        "boom": "0.4.2",
+                        "cryptiles": "0.2.2",
+                        "hoek": "0.9.1",
+                        "sntp": "0.2.4"
+                      },
+                      "dependencies": {
+                        "boom": {
+                          "version": "0.4.2",
+                          "bundled": true,
+                          "requires": {
+                            "hoek": "0.9.1"
+                          }
+                        },
+                        "cryptiles": {
+                          "version": "0.2.2",
+                          "bundled": true,
+                          "requires": {
+                            "boom": "0.4.2"
+                          }
+                        },
+                        "hoek": {
+                          "version": "0.9.1",
+                          "bundled": true
+                        },
+                        "sntp": {
+                          "version": "0.2.4",
+                          "bundled": true,
+                          "requires": {
+                            "hoek": "0.9.1"
+                          }
+                        }
+                      }
+                    },
+                    "http-signature": {
+                      "version": "0.10.1",
+                      "bundled": true,
+                      "requires": {
+                        "asn1": "0.1.11",
+                        "assert-plus": "0.1.5",
+                        "ctype": "0.5.3"
+                      },
+                      "dependencies": {
+                        "asn1": {
+                          "version": "0.1.11",
+                          "bundled": true
+                        },
+                        "assert-plus": {
+                          "version": "0.1.5",
+                          "bundled": true
+                        },
+                        "ctype": {
+                          "version": "0.5.3",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "bundled": true
+                    },
+                    "mime-types": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    },
+                    "oauth-sign": {
+                      "version": "0.5.0",
+                      "bundled": true
+                    },
+                    "qs": {
+                      "version": "2.3.3",
+                      "bundled": true
+                    },
+                    "stringstream": {
+                      "version": "0.0.4",
+                      "bundled": true
+                    },
+                    "tough-cookie": {
+                      "version": "1.2.0",
+                      "bundled": true
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "request-replay": {
+                  "version": "0.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "retry": "0.6.1"
+                  }
+                },
+                "rimraf": {
+                  "version": "2.2.8",
+                  "bundled": true
+                }
+              }
+            },
+            "cardinal": {
+              "version": "0.4.4",
+              "bundled": true,
+              "requires": {
+                "ansicolors": "0.2.1",
+                "redeyed": "0.4.4"
+              },
+              "dependencies": {
+                "ansicolors": {
+                  "version": "0.2.1",
+                  "bundled": true
+                },
+                "redeyed": {
+                  "version": "0.4.4",
+                  "bundled": true,
+                  "requires": {
+                    "esprima": "1.0.4"
+                  },
+                  "dependencies": {
+                    "esprima": {
+                      "version": "1.0.4",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "chmodr": {
+              "version": "0.1.0",
+              "bundled": true
+            },
+            "decompress-zip": {
+              "version": "0.1.0",
+              "bundled": true,
+              "requires": {
+                "binary": "0.3.0",
+                "graceful-fs": "3.0.8",
+                "mkpath": "0.1.0",
+                "nopt": "3.0.2",
+                "q": "1.4.1",
+                "readable-stream": "1.1.13",
+                "touch": "0.0.3"
+              },
+              "dependencies": {
+                "binary": {
+                  "version": "0.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "buffers": "0.1.1",
+                    "chainsaw": "0.1.0"
+                  },
+                  "dependencies": {
+                    "buffers": {
+                      "version": "0.1.1",
+                      "bundled": true
+                    },
+                    "chainsaw": {
+                      "version": "0.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "traverse": "0.3.9"
+                      },
+                      "dependencies": {
+                        "traverse": {
+                          "version": "0.3.9",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "mkpath": {
+                  "version": "0.1.0",
+                  "bundled": true
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "bundled": true,
+                  "requires": {
+                    "core-util-is": "1.0.1",
+                    "inherits": "2.0.1",
+                    "isarray": "0.0.1",
+                    "string_decoder": "0.10.31"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "bundled": true
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "bundled": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "bundled": true
+                    }
+                  }
+                },
+                "touch": {
+                  "version": "0.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "nopt": "1.0.10"
+                  },
+                  "dependencies": {
+                    "nopt": {
+                      "version": "1.0.10",
+                      "bundled": true,
+                      "requires": {
+                        "abbrev": "1.1.1"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "fstream": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "3.0.8",
+                "inherits": "2.0.1",
+                "mkdirp": "0.5.0",
+                "rimraf": "2.3.2"
+              },
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "fstream-ignore": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "fstream": "1.0.6",
+                "inherits": "2.0.1",
+                "minimatch": "2.0.8"
+              },
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "glob": {
+              "version": "4.5.3",
+              "bundled": true,
+              "requires": {
+                "inflight": "1.0.4",
+                "inherits": "2.0.1",
+                "minimatch": "2.0.8",
+                "once": "1.3.2"
+              },
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "once": "1.3.2",
+                    "wrappy": "1.0.1"
+                  },
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "bundled": true
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "bundled": true,
+                  "requires": {
+                    "wrappy": "1.0.1"
+                  },
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "3.0.8",
+              "bundled": true
+            },
+            "handlebars": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "optimist": "0.3.7",
+                "uglify-js": "2.3.6"
+              },
+              "dependencies": {
+                "optimist": {
+                  "version": "0.3.7",
+                  "bundled": true,
+                  "requires": {
+                    "wordwrap": "0.0.3"
+                  },
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "bundled": true
+                    }
+                  }
+                },
+                "uglify-js": {
+                  "version": "2.3.6",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "async": "0.2.10",
+                    "optimist": "0.3.7",
+                    "source-map": "0.1.43"
+                  },
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "bundled": true,
+                      "optional": true
+                    },
+                    "source-map": {
+                      "version": "0.1.43",
+                      "bundled": true,
+                      "optional": true,
+                      "requires": {
+                        "amdefine": "0.1.0"
+                      },
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.0",
+                          "bundled": true,
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "inquirer": {
+              "version": "0.8.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "1.1.1",
+                "chalk": "0.5.1",
+                "cli-color": "0.3.3",
+                "figures": "1.3.5",
+                "lodash": "2.4.2",
+                "mute-stream": "0.0.4",
+                "readline2": "0.1.1",
+                "rx": "2.5.3",
+                "through": "2.3.7"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "bundled": true
+                },
+                "chalk": {
+                  "version": "0.5.1",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-styles": "1.1.0",
+                    "escape-string-regexp": "1.0.5",
+                    "has-ansi": "0.1.0",
+                    "strip-ansi": "0.3.0",
+                    "supports-color": "0.2.0"
+                  },
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "1.1.0",
+                      "bundled": true
+                    },
+                    "has-ansi": {
+                      "version": "0.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-regex": "0.2.1"
+                      },
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "0.2.1",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "0.3.0",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-regex": "0.2.1"
+                      },
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "0.2.1",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "0.2.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "cli-color": {
+                  "version": "0.3.3",
+                  "bundled": true,
+                  "requires": {
+                    "d": "0.1.1",
+                    "es5-ext": "0.10.7",
+                    "memoizee": "0.3.8",
+                    "timers-ext": "0.1.0"
+                  },
+                  "dependencies": {
+                    "d": {
+                      "version": "0.1.1",
+                      "bundled": true,
+                      "requires": {
+                        "es5-ext": "0.10.7"
+                      }
+                    },
+                    "es5-ext": {
+                      "version": "0.10.7",
+                      "bundled": true,
+                      "requires": {
+                        "es6-iterator": "0.1.3",
+                        "es6-symbol": "2.0.1"
+                      },
+                      "dependencies": {
+                        "es6-iterator": {
+                          "version": "0.1.3",
+                          "bundled": true,
+                          "requires": {
+                            "d": "0.1.1",
+                            "es5-ext": "0.10.7",
+                            "es6-symbol": "2.0.1"
+                          }
+                        },
+                        "es6-symbol": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "d": "0.1.1",
+                            "es5-ext": "0.10.7"
+                          }
+                        }
+                      }
+                    },
+                    "memoizee": {
+                      "version": "0.3.8",
+                      "bundled": true,
+                      "requires": {
+                        "d": "0.1.1",
+                        "es5-ext": "0.10.7",
+                        "es6-weak-map": "0.1.4",
+                        "event-emitter": "0.3.3",
+                        "lru-queue": "0.1.0",
+                        "next-tick": "0.2.2",
+                        "timers-ext": "0.1.0"
+                      },
+                      "dependencies": {
+                        "es6-weak-map": {
+                          "version": "0.1.4",
+                          "bundled": true,
+                          "requires": {
+                            "d": "0.1.1",
+                            "es5-ext": "0.10.7",
+                            "es6-iterator": "0.1.3",
+                            "es6-symbol": "2.0.1"
+                          },
+                          "dependencies": {
+                            "es6-iterator": {
+                              "version": "0.1.3",
+                              "bundled": true,
+                              "requires": {
+                                "d": "0.1.1",
+                                "es5-ext": "0.10.7",
+                                "es6-symbol": "2.0.1"
+                              }
+                            },
+                            "es6-symbol": {
+                              "version": "2.0.1",
+                              "bundled": true,
+                              "requires": {
+                                "d": "0.1.1",
+                                "es5-ext": "0.10.7"
+                              }
+                            }
+                          }
+                        },
+                        "event-emitter": {
+                          "version": "0.3.3",
+                          "bundled": true,
+                          "requires": {
+                            "d": "0.1.1",
+                            "es5-ext": "0.10.7"
+                          }
+                        },
+                        "lru-queue": {
+                          "version": "0.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "es5-ext": "0.10.7"
+                          }
+                        },
+                        "next-tick": {
+                          "version": "0.2.2",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "timers-ext": {
+                      "version": "0.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "es5-ext": "0.10.7",
+                        "next-tick": "0.2.2"
+                      },
+                      "dependencies": {
+                        "next-tick": {
+                          "version": "0.2.2",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "figures": {
+                  "version": "1.3.5",
+                  "bundled": true
+                },
+                "lodash": {
+                  "version": "2.4.2",
+                  "bundled": true
+                },
+                "mute-stream": {
+                  "version": "0.0.4",
+                  "bundled": true
+                },
+                "rx": {
+                  "version": "2.5.3",
+                  "bundled": true
+                }
+              }
+            },
+            "insight": {
+              "version": "0.5.3",
+              "bundled": true,
+              "requires": {
+                "async": "0.9.2",
+                "chalk": "1.0.0",
+                "configstore": "0.3.2",
+                "inquirer": "0.8.0",
+                "lodash.debounce": "3.1.0",
+                "object-assign": "2.0.0",
+                "os-name": "1.0.3",
+                "request": "2.53.0",
+                "tough-cookie": "0.12.1"
+              },
+              "dependencies": {
+                "async": {
+                  "version": "0.9.2",
+                  "bundled": true
+                },
+                "lodash.debounce": {
+                  "version": "3.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "lodash._getnative": "3.9.0"
+                  },
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "2.0.0",
+                  "bundled": true
+                },
+                "os-name": {
+                  "version": "1.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "osx-release": "1.0.0",
+                    "win-release": "1.0.0"
+                  },
+                  "dependencies": {
+                    "osx-release": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "minimist": "1.1.1"
+                      },
+                      "dependencies": {
+                        "minimist": {
+                          "version": "1.1.1",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "win-release": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "tough-cookie": {
+                  "version": "0.12.1",
+                  "bundled": true,
+                  "requires": {
+                    "punycode": "1.3.2"
+                  },
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.3.2",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "is-root": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "junk": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "lockfile": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "lru-cache": {
+              "version": "2.6.4",
+              "bundled": true
+            },
+            "mkdirp": {
+              "version": "0.5.0",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "bundled": true
+                }
+              }
+            },
+            "mout": {
+              "version": "0.11.0",
+              "bundled": true
+            },
+            "opn": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "p-throttler": {
+              "version": "0.1.1",
+              "bundled": true,
+              "requires": {
+                "q": "0.9.7"
+              },
+              "dependencies": {
+                "q": {
+                  "version": "0.9.7",
+                  "bundled": true
+                }
+              }
+            },
+            "promptly": {
+              "version": "0.2.0",
+              "bundled": true,
+              "requires": {
+                "read": "1.0.6"
+              },
+              "dependencies": {
+                "read": {
+                  "version": "1.0.6",
+                  "bundled": true,
+                  "requires": {
+                    "mute-stream": "0.0.5"
+                  },
+                  "dependencies": {
+                    "mute-stream": {
+                      "version": "0.0.5",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "q": {
+              "version": "1.4.1",
+              "bundled": true
+            },
+            "request": {
+              "version": "2.53.0",
+              "bundled": true,
+              "requires": {
+                "aws-sign2": "0.5.0",
+                "bl": "0.9.4",
+                "caseless": "0.9.0",
+                "combined-stream": "0.0.7",
+                "forever-agent": "0.5.2",
+                "form-data": "0.2.0",
+                "hawk": "2.3.1",
+                "http-signature": "0.10.1",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.0.13",
+                "node-uuid": "1.4.3",
+                "oauth-sign": "0.6.0",
+                "qs": "2.3.3",
+                "stringstream": "0.0.4",
+                "tough-cookie": "1.2.0",
+                "tunnel-agent": "0.4.0"
+              },
+              "dependencies": {
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "bundled": true
+                },
+                "bl": {
+                  "version": "0.9.4",
+                  "bundled": true,
+                  "requires": {
+                    "readable-stream": "1.0.33"
+                  },
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "bundled": true,
+                      "requires": {
+                        "core-util-is": "1.0.1",
+                        "inherits": "2.0.1",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "bundled": true
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "bundled": true
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "bundled": true
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.9.0",
+                  "bundled": true
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "bundled": true,
+                  "requires": {
+                    "delayed-stream": "0.0.5"
+                  },
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "bundled": true
+                    }
+                  }
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "bundled": true
+                },
+                "form-data": {
+                  "version": "0.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "async": "0.9.2",
+                    "combined-stream": "0.0.7",
+                    "mime-types": "2.0.13"
+                  },
+                  "dependencies": {
+                    "async": {
+                      "version": "0.9.2",
+                      "bundled": true
+                    }
+                  }
+                },
+                "hawk": {
+                  "version": "2.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "boom": "2.7.2",
+                    "cryptiles": "2.0.4",
+                    "hoek": "2.14.0",
+                    "sntp": "1.0.9"
+                  },
+                  "dependencies": {
+                    "boom": {
+                      "version": "2.7.2",
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "2.14.0"
+                      }
+                    },
+                    "cryptiles": {
+                      "version": "2.0.4",
+                      "bundled": true,
+                      "requires": {
+                        "boom": "2.7.2"
+                      }
+                    },
+                    "hoek": {
+                      "version": "2.14.0",
+                      "bundled": true
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "2.14.0"
+                      }
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "bundled": true,
+                  "requires": {
+                    "asn1": "0.1.11",
+                    "assert-plus": "0.1.5",
+                    "ctype": "0.5.3"
+                  },
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.1.11",
+                      "bundled": true
+                    },
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "bundled": true
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "bundled": true
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "bundled": true
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "bundled": true
+                },
+                "mime-types": {
+                  "version": "2.0.13",
+                  "bundled": true,
+                  "requires": {
+                    "mime-db": "1.11.0"
+                  },
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.11.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.6.0",
+                  "bundled": true
+                },
+                "qs": {
+                  "version": "2.3.3",
+                  "bundled": true
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "bundled": true
+                },
+                "tough-cookie": {
+                  "version": "1.2.0",
+                  "bundled": true
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "bundled": true
+                }
+              }
+            },
+            "request-progress": {
+              "version": "0.3.1",
+              "bundled": true,
+              "requires": {
+                "throttleit": "0.0.2"
+              },
+              "dependencies": {
+                "throttleit": {
+                  "version": "0.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "retry": {
+              "version": "0.6.1",
+              "bundled": true
+            },
+            "semver": {
+              "version": "2.3.2",
+              "bundled": true
+            },
+            "shell-quote": {
+              "version": "1.4.3",
+              "bundled": true,
+              "requires": {
+                "array-filter": "0.0.1",
+                "array-map": "0.0.0",
+                "array-reduce": "0.0.0",
+                "jsonify": "0.0.0"
+              },
+              "dependencies": {
+                "array-filter": {
+                  "version": "0.0.1",
+                  "bundled": true
+                },
+                "array-map": {
+                  "version": "0.0.0",
+                  "bundled": true
+                },
+                "array-reduce": {
+                  "version": "0.0.0",
+                  "bundled": true
+                },
+                "jsonify": {
+                  "version": "0.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "stringify-object": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "tar-fs": {
+              "version": "1.5.1",
+              "bundled": true,
+              "requires": {
+                "mkdirp": "0.5.0",
+                "pump": "1.0.0",
+                "tar-stream": "1.1.5"
+              },
+              "dependencies": {
+                "pump": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "end-of-stream": "1.1.0",
+                    "once": "1.3.2"
+                  },
+                  "dependencies": {
+                    "end-of-stream": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "once": "1.3.2"
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "bundled": true,
+                      "requires": {
+                        "wrappy": "1.0.1"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "tar-stream": {
+                  "version": "1.1.5",
+                  "bundled": true,
+                  "requires": {
+                    "bl": "0.9.4",
+                    "end-of-stream": "1.1.0",
+                    "readable-stream": "1.0.33",
+                    "xtend": "4.0.0"
+                  },
+                  "dependencies": {
+                    "bl": {
+                      "version": "0.9.4",
+                      "bundled": true,
+                      "requires": {
+                        "readable-stream": "1.0.33"
+                      }
+                    },
+                    "end-of-stream": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "once": "1.3.2"
+                      },
+                      "dependencies": {
+                        "once": {
+                          "version": "1.3.2",
+                          "bundled": true,
+                          "requires": {
+                            "wrappy": "1.0.1"
+                          },
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "bundled": true,
+                      "requires": {
+                        "core-util-is": "1.0.1",
+                        "inherits": "2.0.1",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "bundled": true
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "bundled": true
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "bundled": true
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "4.0.0",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "tmp": {
+              "version": "0.0.24",
+              "bundled": true
+            },
+            "update-notifier": {
+              "version": "0.3.2",
+              "bundled": true,
+              "requires": {
+                "chalk": "1.0.0",
+                "configstore": "0.3.2",
+                "is-npm": "1.0.0",
+                "latest-version": "1.0.0",
+                "semver-diff": "2.0.0",
+                "string-length": "1.0.0"
+              },
+              "dependencies": {
+                "is-npm": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "latest-version": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "package-json": "1.1.0"
+                  },
+                  "dependencies": {
+                    "package-json": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "got": "2.9.2",
+                        "registry-url": "3.0.3"
+                      },
+                      "dependencies": {
+                        "got": {
+                          "version": "2.9.2",
+                          "bundled": true,
+                          "requires": {
+                            "duplexify": "3.4.1",
+                            "infinity-agent": "2.0.3",
+                            "is-stream": "1.0.1",
+                            "lowercase-keys": "1.0.0",
+                            "nested-error-stacks": "1.0.0",
+                            "object-assign": "2.0.0",
+                            "prepend-http": "1.0.1",
+                            "read-all-stream": "2.1.2",
+                            "statuses": "1.2.1",
+                            "timed-out": "2.0.0"
+                          },
+                          "dependencies": {
+                            "duplexify": {
+                              "version": "3.4.1",
+                              "bundled": true,
+                              "requires": {
+                                "end-of-stream": "1.0.0",
+                                "readable-stream": "1.1.13"
+                              },
+                              "dependencies": {
+                                "end-of-stream": {
+                                  "version": "1.0.0",
+                                  "bundled": true,
+                                  "requires": {
+                                    "once": "1.3.2"
+                                  },
+                                  "dependencies": {
+                                    "once": {
+                                      "version": "1.3.2",
+                                      "bundled": true,
+                                      "requires": {
+                                        "wrappy": "1.0.1"
+                                      },
+                                      "dependencies": {
+                                        "wrappy": {
+                                          "version": "1.0.1",
+                                          "bundled": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "readable-stream": {
+                                  "version": "1.1.13",
+                                  "bundled": true,
+                                  "requires": {
+                                    "core-util-is": "1.0.1",
+                                    "inherits": "2.0.1",
+                                    "isarray": "0.0.1",
+                                    "string_decoder": "0.10.31"
+                                  },
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "bundled": true
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "bundled": true
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "bundled": true
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "bundled": true
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "infinity-agent": {
+                              "version": "2.0.3",
+                              "bundled": true
+                            },
+                            "is-stream": {
+                              "version": "1.0.1",
+                              "bundled": true
+                            },
+                            "lowercase-keys": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            },
+                            "nested-error-stacks": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            },
+                            "object-assign": {
+                              "version": "2.0.0",
+                              "bundled": true
+                            },
+                            "prepend-http": {
+                              "version": "1.0.1",
+                              "bundled": true
+                            },
+                            "read-all-stream": {
+                              "version": "2.1.2",
+                              "bundled": true,
+                              "requires": {
+                                "readable-stream": "1.1.13"
+                              },
+                              "dependencies": {
+                                "readable-stream": {
+                                  "version": "1.1.13",
+                                  "bundled": true,
+                                  "requires": {
+                                    "core-util-is": "1.0.1",
+                                    "inherits": "2.0.1",
+                                    "isarray": "0.0.1",
+                                    "string_decoder": "0.10.31"
+                                  },
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "bundled": true
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "bundled": true
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "bundled": true
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "bundled": true
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "statuses": {
+                              "version": "1.2.1",
+                              "bundled": true
+                            },
+                            "timed-out": {
+                              "version": "2.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "registry-url": {
+                          "version": "3.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "rc": "1.0.3"
+                          },
+                          "dependencies": {
+                            "rc": {
+                              "version": "1.0.3",
+                              "bundled": true,
+                              "requires": {
+                                "deep-extend": "0.2.11",
+                                "ini": "1.3.3",
+                                "minimist": "0.0.10",
+                                "strip-json-comments": "0.1.3"
+                              },
+                              "dependencies": {
+                                "deep-extend": {
+                                  "version": "0.2.11",
+                                  "bundled": true
+                                },
+                                "ini": {
+                                  "version": "1.3.3",
+                                  "bundled": true
+                                },
+                                "minimist": {
+                                  "version": "0.0.10",
+                                  "bundled": true
+                                },
+                                "strip-json-comments": {
+                                  "version": "0.1.3",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "semver-diff": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "semver": "4.3.6"
+                  },
+                  "dependencies": {
+                    "semver": {
+                      "version": "4.3.6",
+                      "bundled": true
+                    }
+                  }
+                },
+                "string-length": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "strip-ansi": "2.0.1"
+                  }
+                }
+              }
+            },
+            "user-home": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "which": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "is-absolute": "0.1.7"
+              },
+              "dependencies": {
+                "is-absolute": {
+                  "version": "0.1.7",
+                  "bundled": true,
+                  "requires": {
+                    "is-relative": "0.1.3"
+                  },
+                  "dependencies": {
+                    "is-relative": {
+                      "version": "0.1.3",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "bower-config": {
+          "version": "0.5.2",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "2.0.3",
+            "mout": "0.9.1",
+            "optimist": "0.6.1",
+            "osenv": "0.0.3"
+          },
+          "dependencies": {
+            "graceful-fs": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "mout": {
+              "version": "0.9.1",
+              "bundled": true
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.10",
+                "wordwrap": "0.0.3"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.10",
+                  "bundled": true
+                },
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "bundled": true
+                }
+              }
+            },
+            "osenv": {
+              "version": "0.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "broccoli": {
+          "version": "0.15.4",
+          "bundled": true,
+          "requires": {
+            "broccoli-kitchen-sink-helpers": "0.2.6",
+            "broccoli-slow-trees": "1.1.0",
+            "commander": "2.8.1",
+            "connect": "3.3.5",
+            "copy-dereference": "1.0.0",
+            "findup-sync": "0.2.1",
+            "handlebars": "3.0.3",
+            "mime": "1.3.4",
+            "promise-map-series": "0.2.3",
+            "quick-temp": "0.1.2",
+            "rimraf": "2.3.2",
+            "rsvp": "3.6.2",
+            "tiny-lr": "0.1.5"
+          },
+          "dependencies": {
+            "broccoli-slow-trees": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "commander": {
+              "version": "2.8.1",
+              "bundled": true,
+              "requires": {
+                "graceful-readlink": "1.0.1"
+              },
+              "dependencies": {
+                "graceful-readlink": {
+                  "version": "1.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "connect": {
+              "version": "3.3.5",
+              "bundled": true,
+              "requires": {
+                "debug": "2.1.3",
+                "finalhandler": "0.3.4",
+                "parseurl": "1.3.0",
+                "utils-merge": "1.0.0"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "2.1.3",
+                  "bundled": true,
+                  "requires": {
+                    "ms": "0.7.0"
+                  },
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "finalhandler": {
+                  "version": "0.3.4",
+                  "bundled": true,
+                  "requires": {
+                    "debug": "2.1.3",
+                    "escape-html": "1.0.1",
+                    "on-finished": "2.2.1"
+                  },
+                  "dependencies": {
+                    "escape-html": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    },
+                    "on-finished": {
+                      "version": "2.2.1",
+                      "bundled": true,
+                      "requires": {
+                        "ee-first": "1.1.0"
+                      },
+                      "dependencies": {
+                        "ee-first": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "parseurl": {
+                  "version": "1.3.0",
+                  "bundled": true
+                },
+                "utils-merge": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "copy-dereference": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "findup-sync": {
+              "version": "0.2.1",
+              "bundled": true,
+              "requires": {
+                "glob": "4.3.5"
+              },
+              "dependencies": {
+                "glob": {
+                  "version": "4.3.5",
+                  "bundled": true,
+                  "requires": {
+                    "inflight": "1.0.4",
+                    "inherits": "2.0.1",
+                    "minimatch": "2.0.8",
+                    "once": "1.3.2"
+                  },
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "bundled": true,
+                      "requires": {
+                        "once": "1.3.2",
+                        "wrappy": "1.0.1"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "bundled": true
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "bundled": true,
+                      "requires": {
+                        "wrappy": "1.0.1"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "handlebars": {
+              "version": "3.0.3",
+              "bundled": true,
+              "requires": {
+                "optimist": "0.6.1",
+                "source-map": "0.1.43",
+                "uglify-js": "2.3.6"
+              },
+              "dependencies": {
+                "optimist": {
+                  "version": "0.6.1",
+                  "bundled": true,
+                  "requires": {
+                    "minimist": "0.0.10",
+                    "wordwrap": "0.0.3"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.10",
+                      "bundled": true
+                    },
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "bundled": true
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "bundled": true,
+                  "requires": {
+                    "amdefine": "0.1.0"
+                  },
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "uglify-js": {
+                  "version": "2.3.6",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "async": "0.2.10",
+                    "optimist": "0.3.7",
+                    "source-map": "0.1.43"
+                  },
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "bundled": true,
+                      "optional": true
+                    },
+                    "optimist": {
+                      "version": "0.3.7",
+                      "bundled": true,
+                      "optional": true,
+                      "requires": {
+                        "wordwrap": "0.0.3"
+                      },
+                      "dependencies": {
+                        "wordwrap": {
+                          "version": "0.0.3",
+                          "bundled": true,
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "mime": {
+              "version": "1.3.4",
+              "bundled": true
+            }
+          }
+        },
+        "broccoli-clean-css": {
+          "version": "0.2.0",
+          "bundled": true,
+          "requires": {
+            "broccoli-filter": "0.1.12",
+            "clean-css": "2.2.23"
+          },
+          "dependencies": {
+            "clean-css": {
+              "version": "2.2.23",
+              "bundled": true,
+              "requires": {
+                "commander": "2.2.0"
+              },
+              "dependencies": {
+                "commander": {
+                  "version": "2.2.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "chalk": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "2.0.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "1.0.3",
+            "strip-ansi": "2.0.1",
+            "supports-color": "1.3.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "has-ansi": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "1.1.1",
+                "get-stdin": "4.0.1"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "bundled": true
+                },
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "supports-color": {
+              "version": "1.3.1",
+              "bundled": true
+            }
+          }
+        },
+        "concat-stream": {
+          "version": "1.4.8",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.1",
+            "readable-stream": "1.1.13",
+            "typedarray": "0.0.6"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "1.0.1",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+              },
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "bundled": true
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "bundled": true
+                }
+              }
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "bundled": true
+            }
+          }
+        },
+        "configstore": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "3.0.8",
+            "js-yaml": "3.3.1",
+            "mkdirp": "0.5.1",
+            "object-assign": "2.0.0",
+            "osenv": "0.1.1",
+            "user-home": "1.1.1",
+            "uuid": "2.0.1",
+            "xdg-basedir": "1.0.1"
+          },
+          "dependencies": {
+            "graceful-fs": {
+              "version": "3.0.8",
+              "bundled": true
+            },
+            "js-yaml": {
+              "version": "3.3.1",
+              "bundled": true,
+              "requires": {
+                "argparse": "1.0.2",
+                "esprima": "2.2.0"
+              },
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "lodash": "3.9.3",
+                    "sprintf-js": "1.0.2"
+                  },
+                  "dependencies": {
+                    "sprintf-js": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.2.0",
+                  "bundled": true
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "bundled": true
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "osenv": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "user-home": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "uuid": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "xdg-basedir": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "user-home": "1.1.1"
+              }
+            }
+          }
+        },
+        "diff": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "express": {
+          "version": "4.12.4",
+          "bundled": true,
+          "requires": {
+            "accepts": "1.2.7",
+            "content-disposition": "0.5.0",
+            "content-type": "1.0.1",
+            "cookie": "0.1.2",
+            "cookie-signature": "1.0.6",
+            "debug": "2.2.0",
+            "depd": "1.0.1",
+            "escape-html": "1.0.1",
+            "etag": "1.6.0",
+            "finalhandler": "0.3.6",
+            "fresh": "0.2.4",
+            "merge-descriptors": "1.0.0",
+            "methods": "1.1.1",
+            "on-finished": "2.2.1",
+            "parseurl": "1.3.0",
+            "path-to-regexp": "0.1.3",
+            "proxy-addr": "1.0.8",
+            "qs": "2.4.2",
+            "range-parser": "1.0.2",
+            "send": "0.12.3",
+            "serve-static": "1.9.3",
+            "type-is": "1.6.2",
+            "utils-merge": "1.0.0",
+            "vary": "1.0.0"
+          },
+          "dependencies": {
+            "accepts": {
+              "version": "1.2.7",
+              "bundled": true,
+              "requires": {
+                "mime-types": "2.0.13",
+                "negotiator": "0.5.3"
+              },
+              "dependencies": {
+                "mime-types": {
+                  "version": "2.0.13",
+                  "bundled": true,
+                  "requires": {
+                    "mime-db": "1.11.0"
+                  },
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.11.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "negotiator": {
+                  "version": "0.5.3",
+                  "bundled": true
+                }
+              }
+            },
+            "content-disposition": {
+              "version": "0.5.0",
+              "bundled": true
+            },
+            "content-type": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "cookie": {
+              "version": "0.1.2",
+              "bundled": true
+            },
+            "cookie-signature": {
+              "version": "1.0.6",
+              "bundled": true
+            },
+            "debug": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+              "requires": {
+                "ms": "0.7.1"
+              }
+            },
+            "depd": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "escape-html": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "etag": {
+              "version": "1.6.0",
+              "bundled": true,
+              "requires": {
+                "crc": "3.2.1"
+              },
+              "dependencies": {
+                "crc": {
+                  "version": "3.2.1",
+                  "bundled": true
+                }
+              }
+            },
+            "finalhandler": {
+              "version": "0.3.6",
+              "bundled": true,
+              "requires": {
+                "debug": "2.2.0",
+                "escape-html": "1.0.1",
+                "on-finished": "2.2.1"
+              }
+            },
+            "fresh": {
+              "version": "0.2.4",
+              "bundled": true
+            },
+            "merge-descriptors": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "methods": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "on-finished": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "ee-first": "1.1.0"
+              },
+              "dependencies": {
+                "ee-first": {
+                  "version": "1.1.0",
+                  "bundled": true
+                }
+              }
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "bundled": true
+            },
+            "path-to-regexp": {
+              "version": "0.1.3",
+              "bundled": true
+            },
+            "proxy-addr": {
+              "version": "1.0.8",
+              "bundled": true,
+              "requires": {
+                "forwarded": "0.1.0",
+                "ipaddr.js": "1.0.1"
+              },
+              "dependencies": {
+                "forwarded": {
+                  "version": "0.1.0",
+                  "bundled": true
+                },
+                "ipaddr.js": {
+                  "version": "1.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "qs": {
+              "version": "2.4.2",
+              "bundled": true
+            },
+            "range-parser": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "send": {
+              "version": "0.12.3",
+              "bundled": true,
+              "requires": {
+                "debug": "2.2.0",
+                "depd": "1.0.1",
+                "destroy": "1.0.3",
+                "escape-html": "1.0.1",
+                "etag": "1.6.0",
+                "fresh": "0.2.4",
+                "mime": "1.3.4",
+                "ms": "0.7.1",
+                "on-finished": "2.2.1",
+                "range-parser": "1.0.2"
+              },
+              "dependencies": {
+                "destroy": {
+                  "version": "1.0.3",
+                  "bundled": true
+                },
+                "mime": {
+                  "version": "1.3.4",
+                  "bundled": true
+                },
+                "ms": {
+                  "version": "0.7.1",
+                  "bundled": true
+                }
+              }
+            },
+            "serve-static": {
+              "version": "1.9.3",
+              "bundled": true,
+              "requires": {
+                "escape-html": "1.0.1",
+                "parseurl": "1.3.0",
+                "send": "0.12.3",
+                "utils-merge": "1.0.0"
+              }
+            },
+            "type-is": {
+              "version": "1.6.2",
+              "bundled": true,
+              "requires": {
+                "media-typer": "0.3.0",
+                "mime-types": "2.0.13"
+              },
+              "dependencies": {
+                "media-typer": {
+                  "version": "0.3.0",
+                  "bundled": true
+                },
+                "mime-types": {
+                  "version": "2.0.13",
+                  "bundled": true,
+                  "requires": {
+                    "mime-db": "1.11.0"
+                  },
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.11.0",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "utils-merge": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "vary": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "findup": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "colors": "0.6.2",
+            "commander": "2.1.0"
+          },
+          "dependencies": {
+            "colors": {
+              "version": "0.6.2",
+              "bundled": true
+            },
+            "commander": {
+              "version": "2.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "fs-extra": {
+          "version": "0.16.5",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "3.0.8",
+            "jsonfile": "2.0.1",
+            "rimraf": "2.3.2"
+          },
+          "dependencies": {
+            "graceful-fs": {
+              "version": "3.0.8",
+              "bundled": true
+            },
+            "jsonfile": {
+              "version": "2.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "git-repo-info": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "glob": {
+          "version": "5.0.3",
+          "bundled": true,
+          "requires": {
+            "inflight": "1.0.4",
+            "inherits": "2.0.1",
+            "minimatch": "2.0.8",
+            "once": "1.3.2"
+          },
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "bundled": true,
+              "requires": {
+                "once": "1.3.2",
+                "wrappy": "1.0.1"
+              },
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "once": {
+              "version": "1.3.2",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1.0.1"
+              },
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "inflection": {
+          "version": "1.7.1",
+          "bundled": true
+        },
+        "inquirer": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "async": "0.8.0",
+            "chalk": "0.4.0",
+            "cli-color": "0.3.3",
+            "lodash": "2.4.2",
+            "mute-stream": "0.0.4",
+            "readline2": "0.1.1",
+            "through": "2.3.7"
+          },
+          "dependencies": {
+            "async": {
+              "version": "0.8.0",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "0.4.0",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "1.0.0",
+                "has-color": "0.1.7",
+                "strip-ansi": "0.1.1"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "has-color": {
+                  "version": "0.1.7",
+                  "bundled": true
+                },
+                "strip-ansi": {
+                  "version": "0.1.1",
+                  "bundled": true
+                }
+              }
+            },
+            "cli-color": {
+              "version": "0.3.3",
+              "bundled": true,
+              "requires": {
+                "d": "0.1.1",
+                "es5-ext": "0.10.7",
+                "memoizee": "0.3.8",
+                "timers-ext": "0.1.0"
+              },
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "es5-ext": "0.10.7"
+                  }
+                },
+                "es5-ext": {
+                  "version": "0.10.7",
+                  "bundled": true,
+                  "requires": {
+                    "es6-iterator": "0.1.3",
+                    "es6-symbol": "2.0.1"
+                  },
+                  "dependencies": {
+                    "es6-iterator": {
+                      "version": "0.1.3",
+                      "bundled": true,
+                      "requires": {
+                        "d": "0.1.1",
+                        "es5-ext": "0.10.7",
+                        "es6-symbol": "2.0.1"
+                      }
+                    },
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "bundled": true,
+                      "requires": {
+                        "d": "0.1.1",
+                        "es5-ext": "0.10.7"
+                      }
+                    }
+                  }
+                },
+                "memoizee": {
+                  "version": "0.3.8",
+                  "bundled": true,
+                  "requires": {
+                    "d": "0.1.1",
+                    "es5-ext": "0.10.7",
+                    "es6-weak-map": "0.1.4",
+                    "event-emitter": "0.3.3",
+                    "lru-queue": "0.1.0",
+                    "next-tick": "0.2.2",
+                    "timers-ext": "0.1.0"
+                  },
+                  "dependencies": {
+                    "es6-weak-map": {
+                      "version": "0.1.4",
+                      "bundled": true,
+                      "requires": {
+                        "d": "0.1.1",
+                        "es5-ext": "0.10.7",
+                        "es6-iterator": "0.1.3",
+                        "es6-symbol": "2.0.1"
+                      },
+                      "dependencies": {
+                        "es6-iterator": {
+                          "version": "0.1.3",
+                          "bundled": true,
+                          "requires": {
+                            "d": "0.1.1",
+                            "es5-ext": "0.10.7",
+                            "es6-symbol": "2.0.1"
+                          }
+                        },
+                        "es6-symbol": {
+                          "version": "2.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "d": "0.1.1",
+                            "es5-ext": "0.10.7"
+                          }
+                        }
+                      }
+                    },
+                    "event-emitter": {
+                      "version": "0.3.3",
+                      "bundled": true,
+                      "requires": {
+                        "d": "0.1.1",
+                        "es5-ext": "0.10.7"
+                      }
+                    },
+                    "lru-queue": {
+                      "version": "0.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "es5-ext": "0.10.7"
+                      }
+                    },
+                    "next-tick": {
+                      "version": "0.2.2",
+                      "bundled": true
+                    }
+                  }
+                },
+                "timers-ext": {
+                  "version": "0.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "es5-ext": "0.10.7",
+                    "next-tick": "0.2.2"
+                  },
+                  "dependencies": {
+                    "next-tick": {
+                      "version": "0.2.2",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "bundled": true
+            },
+            "mute-stream": {
+              "version": "0.0.4",
+              "bundled": true
+            }
+          }
+        },
+        "leek": {
+          "version": "0.0.18",
+          "bundled": true,
+          "requires": {
+            "debug": "2.1.1",
+            "lodash-node": "2.4.1",
+            "request": "2.53.0",
+            "rsvp": "3.0.17"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "ms": "0.6.2"
+              },
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "bundled": true
+                }
+              }
+            },
+            "lodash-node": {
+              "version": "2.4.1",
+              "bundled": true
+            },
+            "request": {
+              "version": "2.53.0",
+              "bundled": true,
+              "requires": {
+                "aws-sign2": "0.5.0",
+                "bl": "0.9.4",
+                "caseless": "0.9.0",
+                "combined-stream": "0.0.7",
+                "forever-agent": "0.5.2",
+                "form-data": "0.2.0",
+                "hawk": "2.3.1",
+                "http-signature": "0.10.1",
+                "isstream": "0.1.1",
+                "json-stringify-safe": "5.0.0",
+                "mime-types": "2.0.9",
+                "node-uuid": "1.4.2",
+                "oauth-sign": "0.6.0",
+                "qs": "2.3.3",
+                "stringstream": "0.0.4",
+                "tough-cookie": "0.12.1",
+                "tunnel-agent": "0.4.0"
+              },
+              "dependencies": {
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "bundled": true
+                },
+                "bl": {
+                  "version": "0.9.4",
+                  "bundled": true,
+                  "requires": {
+                    "readable-stream": "1.0.33"
+                  },
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "bundled": true,
+                      "requires": {
+                        "core-util-is": "1.0.1",
+                        "inherits": "2.0.1",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "bundled": true
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "bundled": true
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "bundled": true
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.9.0",
+                  "bundled": true
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "bundled": true,
+                  "requires": {
+                    "delayed-stream": "0.0.5"
+                  },
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "bundled": true
+                    }
+                  }
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "bundled": true
+                },
+                "form-data": {
+                  "version": "0.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "async": "0.9.0",
+                    "combined-stream": "0.0.7",
+                    "mime-types": "2.0.9"
+                  },
+                  "dependencies": {
+                    "async": {
+                      "version": "0.9.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "hawk": {
+                  "version": "2.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "boom": "2.6.1",
+                    "cryptiles": "2.0.4",
+                    "hoek": "2.11.1",
+                    "sntp": "1.0.9"
+                  },
+                  "dependencies": {
+                    "boom": {
+                      "version": "2.6.1",
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "2.11.1"
+                      }
+                    },
+                    "cryptiles": {
+                      "version": "2.0.4",
+                      "bundled": true,
+                      "requires": {
+                        "boom": "2.6.1"
+                      }
+                    },
+                    "hoek": {
+                      "version": "2.11.1",
+                      "bundled": true
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "2.11.1"
+                      }
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "bundled": true,
+                  "requires": {
+                    "asn1": "0.1.11",
+                    "assert-plus": "0.1.5",
+                    "ctype": "0.5.3"
+                  },
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.1.11",
+                      "bundled": true
+                    },
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "bundled": true
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "bundled": true
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.1",
+                  "bundled": true
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "bundled": true
+                },
+                "mime-types": {
+                  "version": "2.0.9",
+                  "bundled": true,
+                  "requires": {
+                    "mime-db": "1.7.0"
+                  },
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.7.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.2",
+                  "bundled": true
+                },
+                "oauth-sign": {
+                  "version": "0.6.0",
+                  "bundled": true
+                },
+                "qs": {
+                  "version": "2.3.3",
+                  "bundled": true
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "bundled": true
+                },
+                "tough-cookie": {
+                  "version": "0.12.1",
+                  "bundled": true,
+                  "requires": {
+                    "punycode": "1.3.2"
+                  },
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.3.2",
+                      "bundled": true
+                    }
+                  }
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "bundled": true
+                }
+              }
+            },
+            "rsvp": {
+              "version": "3.0.17",
+              "bundled": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.9.3",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "2.0.8",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.0"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "0.2.0",
+                "concat-map": "0.0.1"
+              },
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.2.0",
+                  "bundled": true
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "morgan": {
+          "version": "1.5.3",
+          "bundled": true,
+          "requires": {
+            "basic-auth": "1.0.1",
+            "debug": "2.2.0",
+            "depd": "1.0.1",
+            "on-finished": "2.2.1"
+          },
+          "dependencies": {
+            "basic-auth": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "debug": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+              "requires": {
+                "ms": "0.7.1"
+              }
+            },
+            "depd": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "on-finished": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "ee-first": "1.1.0"
+              },
+              "dependencies": {
+                "ee-first": {
+                  "version": "1.1.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+        },
+        "node-uuid": {
+          "version": "1.4.3",
+          "bundled": true
+        },
+        "nopt": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1.1.1"
+          }
+        },
+        "npm": {
+          "version": "2.11.0",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1.0.6",
+            "ansi": "0.3.0",
+            "ansi-regex": "1.1.1",
+            "ansicolors": "0.3.2",
+            "ansistyles": "0.1.3",
+            "archy": "1.0.0",
+            "async-some": "1.0.2",
+            "block-stream": "0.0.8",
+            "char-spinner": "1.0.1",
+            "chmodr": "0.1.1",
+            "chownr": "0.0.2",
+            "cmd-shim": "2.0.1",
+            "columnify": "1.5.1",
+            "config-chain": "1.1.8",
+            "dezalgo": "1.0.2",
+            "editor": "1.0.0",
+            "fs-vacuum": "1.2.6",
+            "fs-write-stream-atomic": "1.0.3",
+            "fstream": "1.0.6",
+            "fstream-npm": "1.0.2",
+            "github-url-from-git": "1.4.0",
+            "github-url-from-username-repo": "1.0.2",
+            "glob": "5.0.7",
+            "graceful-fs": "3.0.7",
+            "hosted-git-info": "2.1.4",
+            "inflight": "1.0.4",
+            "inherits": "2.0.1",
+            "ini": "1.3.3",
+            "init-package-json": "1.6.0",
+            "lockfile": "1.0.1",
+            "lru-cache": "2.6.4",
+            "minimatch": "2.0.8",
+            "mkdirp": "0.5.1",
+            "node-gyp": "1.0.3",
+            "nopt": "3.0.2",
+            "normalize-git-url": "1.0.1",
+            "normalize-package-data": "2.2.0",
+            "npm-cache-filename": "1.0.1",
+            "npm-install-checks": "1.0.5",
+            "npm-package-arg": "4.0.1",
+            "npm-registry-client": "6.4.0",
+            "npm-user-validate": "0.1.2",
+            "npmlog": "1.2.1",
+            "once": "1.3.2",
+            "opener": "1.4.1",
+            "osenv": "0.1.1",
+            "path-is-inside": "1.0.1",
+            "read": "1.0.6",
+            "read-installed": "4.0.0",
+            "read-package-json": "2.0.0",
+            "readable-stream": "1.0.33",
+            "realize-package-specifier": "3.0.1",
+            "request": "2.55.0",
+            "retry": "0.6.1",
+            "rimraf": "2.3.4",
+            "semver": "4.3.4",
+            "sha": "1.3.0",
+            "slide": "1.1.6",
+            "sorted-object": "1.0.0",
+            "spdx": "0.4.0",
+            "strip-ansi": "2.0.1",
+            "tar": "2.1.1",
+            "text-table": "0.2.0",
+            "uid-number": "0.0.6",
+            "umask": "1.1.0",
+            "validate-npm-package-name": "2.2.0",
+            "which": "1.1.1",
+            "wrappy": "1.0.1",
+            "write-file-atomic": "1.1.2"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.6",
+              "bundled": true
+            },
+            "ansi": {
+              "version": "0.3.0",
+              "bundled": true
+            },
+            "ansi-regex": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "ansicolors": {
+              "version": "0.3.2",
+              "bundled": true
+            },
+            "ansistyles": {
+              "version": "0.1.3",
+              "bundled": true
+            },
+            "archy": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "async-some": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "dezalgo": "1.0.2"
+              }
+            },
+            "block-stream": {
+              "version": "0.0.8",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.1"
+              }
+            },
+            "char-spinner": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "chmodr": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "chownr": {
+              "version": "0.0.2",
+              "bundled": true
+            },
+            "cmd-shim": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "3.0.7",
+                "mkdirp": "0.5.1"
+              }
+            },
+            "columnify": {
+              "version": "1.5.1",
+              "bundled": true,
+              "requires": {
+                "strip-ansi": "2.0.1",
+                "wcwidth": "1.0.0"
+              },
+              "dependencies": {
+                "wcwidth": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "defaults": "1.0.2"
+                  },
+                  "dependencies": {
+                    "defaults": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "clone": "0.1.19"
+                      },
+                      "dependencies": {
+                        "clone": {
+                          "version": "0.1.19",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "config-chain": {
+              "version": "1.1.8",
+              "bundled": true,
+              "requires": {
+                "ini": "1.3.3",
+                "proto-list": "1.2.3"
+              },
+              "dependencies": {
+                "proto-list": {
+                  "version": "1.2.3",
+                  "bundled": true
+                }
+              }
+            },
+            "dezalgo": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "asap": "1.0.0",
+                "wrappy": "1.0.1"
+              },
+              "dependencies": {
+                "asap": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "editor": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "fs-vacuum": {
+              "version": "1.2.6",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "3.0.7",
+                "path-is-inside": "1.0.1",
+                "rimraf": "2.3.4"
+              }
+            },
+            "fs-write-stream-atomic": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "3.0.7"
+              }
+            },
+            "fstream": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "3.0.7",
+                "inherits": "2.0.1",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.3.4"
+              }
+            },
+            "fstream-npm": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "fstream-ignore": "1.0.2",
+                "inherits": "2.0.1"
+              },
+              "dependencies": {
+                "fstream-ignore": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "fstream": "1.0.6",
+                    "inherits": "2.0.1",
+                    "minimatch": "2.0.8"
+                  }
+                }
+              }
+            },
+            "github-url-from-git": {
+              "version": "1.4.0",
+              "bundled": true
+            },
+            "github-url-from-username-repo": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "glob": {
+              "version": "5.0.7",
+              "bundled": true,
+              "requires": {
+                "inflight": "1.0.4",
+                "inherits": "2.0.1",
+                "minimatch": "2.0.8",
+                "once": "1.3.2",
+                "path-is-absolute": "1.0.0"
+              },
+              "dependencies": {
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "3.0.7",
+              "bundled": true
+            },
+            "hosted-git-info": {
+              "version": "2.1.4",
+              "bundled": true
+            },
+            "inflight": {
+              "version": "1.0.4",
+              "bundled": true,
+              "requires": {
+                "once": "1.3.2",
+                "wrappy": "1.0.1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "ini": {
+              "version": "1.3.3",
+              "bundled": true
+            },
+            "init-package-json": {
+              "version": "1.6.0",
+              "bundled": true,
+              "requires": {
+                "glob": "5.0.7",
+                "npm-package-arg": "4.0.1",
+                "promzard": "0.3.0",
+                "read": "1.0.6",
+                "read-package-json": "2.0.0",
+                "semver": "4.3.4",
+                "validate-npm-package-license": "1.0.0-prerelease-2",
+                "validate-npm-package-name": "2.2.0"
+              },
+              "dependencies": {
+                "promzard": {
+                  "version": "0.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "read": "1.0.6"
+                  }
+                },
+                "validate-npm-package-license": {
+                  "version": "1.0.0-prerelease-2",
+                  "bundled": true,
+                  "requires": {
+                    "spdx": "0.4.0",
+                    "spdx-correct": "1.0.0-prerelease-3"
+                  },
+                  "dependencies": {
+                    "spdx-correct": {
+                      "version": "1.0.0-prerelease-3",
+                      "bundled": true,
+                      "requires": {
+                        "spdx": "0.4.0"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lockfile": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "lru-cache": {
+              "version": "2.6.4",
+              "bundled": true
+            },
+            "minimatch": {
+              "version": "2.0.8",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.0"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "balanced-match": "0.2.0",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "bundled": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "bundled": true
+                }
+              }
+            },
+            "node-gyp": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "fstream": "1.0.6",
+                "glob": "4.5.3",
+                "graceful-fs": "3.0.7",
+                "minimatch": "1.0.0",
+                "mkdirp": "0.5.1",
+                "nopt": "3.0.2",
+                "npmlog": "1.2.1",
+                "osenv": "0.1.1",
+                "request": "2.55.0",
+                "rimraf": "2.3.4",
+                "semver": "4.3.4",
+                "tar": "1.0.3",
+                "which": "1.1.1"
+              },
+              "dependencies": {
+                "glob": {
+                  "version": "4.5.3",
+                  "bundled": true,
+                  "requires": {
+                    "inflight": "1.0.4",
+                    "inherits": "2.0.1",
+                    "minimatch": "2.0.4",
+                    "once": "1.3.2"
+                  },
+                  "dependencies": {
+                    "minimatch": {
+                      "version": "2.0.4",
+                      "bundled": true,
+                      "requires": {
+                        "brace-expansion": "1.1.0"
+                      },
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "bundled": true,
+                          "requires": {
+                            "balanced-match": "0.2.0",
+                            "concat-map": "0.0.1"
+                          },
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "bundled": true
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "lru-cache": "2.6.4",
+                    "sigmund": "1.0.0"
+                  },
+                  "dependencies": {
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "tar": {
+                  "version": "1.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "block-stream": "0.0.8",
+                    "fstream": "1.0.6",
+                    "inherits": "2.0.1"
+                  }
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.2",
+              "bundled": true,
+              "requires": {
+                "abbrev": "1.0.6"
+              }
+            },
+            "normalize-git-url": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "normalize-package-data": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "hosted-git-info": "2.1.4",
+                "semver": "4.3.4",
+                "spdx": "0.4.0"
+              }
+            },
+            "npm-cache-filename": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "npm-install-checks": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "npmlog": "1.2.1",
+                "semver": "4.3.4"
+              }
+            },
+            "npm-package-arg": {
+              "version": "4.0.1",
+              "bundled": true,
+              "requires": {
+                "hosted-git-info": "2.1.4",
+                "semver": "4.3.4"
+              }
+            },
+            "npm-registry-client": {
+              "version": "6.4.0",
+              "bundled": true,
+              "requires": {
+                "chownr": "0.0.2",
+                "concat-stream": "1.4.8",
+                "graceful-fs": "3.0.7",
+                "mkdirp": "0.5.1",
+                "normalize-package-data": "2.2.0",
+                "npm-package-arg": "4.0.1",
+                "npmlog": "4.1.2",
+                "once": "1.3.2",
+                "request": "2.55.0",
+                "retry": "0.6.1",
+                "rimraf": "2.3.4",
+                "semver": "4.3.4",
+                "slide": "1.1.6"
+              },
+              "dependencies": {
+                "concat-stream": {
+                  "version": "1.4.8",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.1",
+                    "readable-stream": "1.1.13",
+                    "typedarray": "0.0.6"
+                  },
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "bundled": true,
+                      "requires": {
+                        "core-util-is": "1.0.1",
+                        "inherits": "2.0.1",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "bundled": true
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "bundled": true
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "bundled": true
+                    }
+                  }
+                },
+                "npmlog": {
+                  "version": "4.1.2",
+                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+                  "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+                  "requires": {
+                    "are-we-there-yet": "1.1.4",
+                    "console-control-strings": "1.1.0",
+                    "gauge": "2.7.4",
+                    "set-blocking": "2.0.0"
+                  }
+                }
+              }
+            },
+            "npm-user-validate": {
+              "version": "0.1.2",
+              "bundled": true
+            },
+            "npmlog": {
+              "version": "1.2.1",
+              "bundled": true,
+              "requires": {
+                "ansi": "0.3.0",
+                "are-we-there-yet": "1.0.4",
+                "gauge": "1.2.0"
+              },
+              "dependencies": {
+                "are-we-there-yet": {
+                  "version": "1.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "delegates": "0.1.0",
+                    "readable-stream": "1.1.13"
+                  },
+                  "dependencies": {
+                    "delegates": {
+                      "version": "0.1.0",
+                      "bundled": true
+                    },
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "bundled": true,
+                      "requires": {
+                        "core-util-is": "1.0.1",
+                        "inherits": "2.0.1",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "bundled": true
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "bundled": true
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "gauge": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi": "0.3.0",
+                    "has-unicode": "1.0.0",
+                    "lodash.pad": "3.1.0",
+                    "lodash.padleft": "3.1.1",
+                    "lodash.padright": "3.1.1"
+                  },
+                  "dependencies": {
+                    "has-unicode": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "lodash._basetostring": {
+                      "version": "3.0.0",
+                      "bundled": true
+                    },
+                    "lodash._createpadding": {
+                      "version": "3.6.0",
+                      "bundled": true,
+                      "requires": {
+                        "lodash.repeat": "3.0.0"
+                      },
+                      "dependencies": {
+                        "lodash.repeat": {
+                          "version": "3.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "lodash._basetostring": "3.0.0"
+                          }
+                        }
+                      }
+                    },
+                    "lodash.pad": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "lodash._basetostring": "3.0.0",
+                        "lodash._createpadding": "3.6.0"
+                      }
+                    },
+                    "lodash.padleft": {
+                      "version": "3.1.1",
+                      "bundled": true,
+                      "requires": {
+                        "lodash._basetostring": "3.0.0",
+                        "lodash._createpadding": "3.6.0"
+                      }
+                    },
+                    "lodash.padright": {
+                      "version": "3.1.1",
+                      "bundled": true,
+                      "requires": {
+                        "lodash._basetostring": "3.0.0",
+                        "lodash._createpadding": "3.6.0"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.2",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1.0.1"
+              }
+            },
+            "opener": {
+              "version": "1.4.1",
+              "bundled": true
+            },
+            "osenv": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "path-is-inside": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "read": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "mute-stream": "0.0.5"
+              },
+              "dependencies": {
+                "mute-stream": {
+                  "version": "0.0.5",
+                  "bundled": true
+                }
+              }
+            },
+            "read-installed": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "debuglog": "1.0.1",
+                "graceful-fs": "3.0.7",
+                "read-package-json": "2.0.0",
+                "readdir-scoped-modules": "1.0.1",
+                "semver": "4.3.4",
+                "slide": "1.1.6",
+                "util-extend": "1.0.1"
+              },
+              "dependencies": {
+                "debuglog": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "readdir-scoped-modules": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "debuglog": "1.0.1",
+                    "dezalgo": "1.0.2",
+                    "graceful-fs": "3.0.7",
+                    "once": "1.3.2"
+                  }
+                },
+                "util-extend": {
+                  "version": "1.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "read-package-json": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "glob": "5.0.7",
+                "graceful-fs": "3.0.7",
+                "json-parse-helpfulerror": "1.0.3",
+                "normalize-package-data": "2.2.0"
+              },
+              "dependencies": {
+                "json-parse-helpfulerror": {
+                  "version": "1.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "jju": "1.2.0"
+                  },
+                  "dependencies": {
+                    "jju": {
+                      "version": "1.2.0",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "1.0.33",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "1.0.1",
+                "inherits": "2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+              },
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "bundled": true
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "bundled": true
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "bundled": true
+                }
+              }
+            },
+            "realize-package-specifier": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "dezalgo": "1.0.2",
+                "npm-package-arg": "4.0.1"
+              }
+            },
+            "request": {
+              "version": "2.55.0",
+              "bundled": true,
+              "requires": {
+                "aws-sign2": "0.5.0",
+                "bl": "0.9.4",
+                "caseless": "0.9.0",
+                "combined-stream": "0.0.7",
+                "forever-agent": "0.6.1",
+                "form-data": "0.2.0",
+                "har-validator": "1.6.1",
+                "hawk": "2.3.1",
+                "http-signature": "0.10.1",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.0",
+                "mime-types": "2.0.10",
+                "node-uuid": "1.4.3",
+                "oauth-sign": "0.6.0",
+                "qs": "2.4.1",
+                "stringstream": "0.0.4",
+                "tough-cookie": "0.12.1",
+                "tunnel-agent": "0.4.0"
+              },
+              "dependencies": {
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "bundled": true
+                },
+                "bl": {
+                  "version": "0.9.4",
+                  "bundled": true,
+                  "requires": {
+                    "readable-stream": "1.0.33"
+                  }
+                },
+                "caseless": {
+                  "version": "0.9.0",
+                  "bundled": true
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "bundled": true,
+                  "requires": {
+                    "delayed-stream": "0.0.5"
+                  },
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "bundled": true
+                    }
+                  }
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "bundled": true
+                },
+                "form-data": {
+                  "version": "0.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "async": "0.9.0",
+                    "combined-stream": "0.0.7",
+                    "mime-types": "2.0.10"
+                  },
+                  "dependencies": {
+                    "async": {
+                      "version": "0.9.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "har-validator": {
+                  "version": "1.6.1",
+                  "bundled": true,
+                  "requires": {
+                    "bluebird": "2.9.24",
+                    "chalk": "1.0.0",
+                    "commander": "2.7.1",
+                    "is-my-json-valid": "2.10.1"
+                  },
+                  "dependencies": {
+                    "bluebird": {
+                      "version": "2.9.24",
+                      "bundled": true
+                    },
+                    "chalk": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-styles": "2.0.1",
+                        "escape-string-regexp": "1.0.3",
+                        "has-ansi": "1.0.3",
+                        "strip-ansi": "2.0.1",
+                        "supports-color": "1.3.1"
+                      },
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.0.1",
+                          "bundled": true
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.3",
+                          "bundled": true
+                        },
+                        "has-ansi": {
+                          "version": "1.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "ansi-regex": "1.1.1",
+                            "get-stdin": "4.0.1"
+                          },
+                          "dependencies": {
+                            "get-stdin": {
+                              "version": "4.0.1",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "1.3.1",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "commander": {
+                      "version": "2.7.1",
+                      "bundled": true,
+                      "requires": {
+                        "graceful-readlink": "1.0.1"
+                      },
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.10.1",
+                      "bundled": true,
+                      "requires": {
+                        "generate-function": "2.0.0",
+                        "generate-object-property": "1.1.1",
+                        "jsonpointer": "1.1.0",
+                        "xtend": "4.0.0"
+                      },
+                      "dependencies": {
+                        "generate-function": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        },
+                        "generate-object-property": {
+                          "version": "1.1.1",
+                          "bundled": true,
+                          "requires": {
+                            "is-property": "1.0.2"
+                          },
+                          "dependencies": {
+                            "is-property": {
+                              "version": "1.0.2",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "jsonpointer": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "xtend": {
+                          "version": "4.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "hawk": {
+                  "version": "2.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "boom": "2.7.0",
+                    "cryptiles": "2.0.4",
+                    "hoek": "2.12.0",
+                    "sntp": "1.0.9"
+                  },
+                  "dependencies": {
+                    "boom": {
+                      "version": "2.7.0",
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "2.12.0"
+                      }
+                    },
+                    "cryptiles": {
+                      "version": "2.0.4",
+                      "bundled": true,
+                      "requires": {
+                        "boom": "2.7.0"
+                      }
+                    },
+                    "hoek": {
+                      "version": "2.12.0",
+                      "bundled": true
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "2.12.0"
+                      }
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "bundled": true,
+                  "requires": {
+                    "asn1": "0.1.11",
+                    "assert-plus": "0.1.5",
+                    "ctype": "0.5.3"
+                  },
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.1.11",
+                      "bundled": true
+                    },
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "bundled": true
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "bundled": true
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "bundled": true
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "bundled": true
+                },
+                "mime-types": {
+                  "version": "2.0.10",
+                  "bundled": true,
+                  "requires": {
+                    "mime-db": "1.8.0"
+                  },
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.8.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "bundled": true
+                },
+                "oauth-sign": {
+                  "version": "0.6.0",
+                  "bundled": true
+                },
+                "qs": {
+                  "version": "2.4.1",
+                  "bundled": true
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "bundled": true
+                },
+                "tough-cookie": {
+                  "version": "0.12.1",
+                  "bundled": true,
+                  "requires": {
+                    "punycode": "1.3.2"
+                  },
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.3.2",
+                      "bundled": true
+                    }
+                  }
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "bundled": true
+                }
+              }
+            },
+            "retry": {
+              "version": "0.6.1",
+              "bundled": true
+            },
+            "rimraf": {
+              "version": "2.3.4",
+              "bundled": true,
+              "requires": {
+                "glob": "4.5.3"
+              },
+              "dependencies": {
+                "glob": {
+                  "version": "4.5.3",
+                  "bundled": true,
+                  "requires": {
+                    "inflight": "1.0.4",
+                    "inherits": "2.0.1",
+                    "minimatch": "2.0.8",
+                    "once": "1.3.2"
+                  }
+                }
+              }
+            },
+            "semver": {
+              "version": "4.3.4",
+              "bundled": true
+            },
+            "sha": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "3.0.7",
+                "readable-stream": "1.1.13"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "core-util-is": "1.0.1",
+                    "inherits": "2.0.1",
+                    "isarray": "0.0.1",
+                    "string_decoder": "0.10.31"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "bundled": true,
+                      "optional": true
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "bundled": true,
+                      "optional": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "bundled": true,
+                      "optional": true
+                    }
+                  }
+                }
+              }
+            },
+            "slide": {
+              "version": "1.1.6",
+              "bundled": true
+            },
+            "sorted-object": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "spdx": {
+              "version": "0.4.0",
+              "bundled": true,
+              "requires": {
+                "spdx-license-ids": "1.0.0"
+              },
+              "dependencies": {
+                "spdx-license-ids": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "1.1.1"
+              }
+            },
+            "tar": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "block-stream": "0.0.8",
+                "fstream": "1.0.6",
+                "inherits": "2.0.1"
+              }
+            },
+            "text-table": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "uid-number": {
+              "version": "0.0.6",
+              "bundled": true
+            },
+            "umask": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "validate-npm-package-name": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "builtins": "0.0.7"
+              },
+              "dependencies": {
+                "builtins": {
+                  "version": "0.0.7",
+                  "bundled": true
+                }
+              }
+            },
+            "which": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "is-absolute": "0.1.7"
+              },
+              "dependencies": {
+                "is-absolute": {
+                  "version": "0.1.7",
+                  "bundled": true,
+                  "requires": {
+                    "is-relative": "0.1.3"
+                  },
+                  "dependencies": {
+                    "is-relative": {
+                      "version": "0.1.3",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "wrappy": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "write-file-atomic": {
+              "version": "1.1.2",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "3.0.7",
+                "slide": "1.1.6"
+              }
+            }
+          }
+        },
+        "proxy-middleware": {
+          "version": "0.11.0",
+          "bundled": true
+        },
+        "quick-temp": {
+          "version": "0.1.2",
+          "bundled": true,
+          "requires": {
+            "mktemp": "0.3.5",
+            "rimraf": "2.2.8",
+            "underscore.string": "2.3.3"
+          },
+          "dependencies": {
+            "mktemp": {
+              "version": "0.3.5",
+              "bundled": true
+            },
+            "rimraf": {
+              "version": "2.2.8",
+              "bundled": true
+            },
+            "underscore.string": {
+              "version": "2.3.3",
+              "bundled": true
+            }
+          }
+        },
+        "readline2": {
+          "version": "0.1.1",
+          "bundled": true,
+          "requires": {
+            "mute-stream": "0.0.4",
+            "strip-ansi": "2.0.1"
+          },
+          "dependencies": {
+            "mute-stream": {
+              "version": "0.0.4",
+              "bundled": true
+            }
+          }
+        },
+        "resolve": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "rimraf": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.2.tgz",
+          "integrity": "sha1-cwS9knXEAbiRA7EGs1McHvDAL+k=",
+          "requires": {
+            "glob": "4.5.3"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "4.5.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+              "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+              "requires": {
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "2.0.8",
+                "once": "1.4.0"
+              }
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+          "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
+          "requires": {
+            "ansi-regex": "1.1.1"
+          }
+        },
+        "through": {
+          "version": "2.3.7",
+          "bundled": true
+        },
+        "tiny-lr": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "body-parser": "1.8.4",
+            "debug": "2.0.0",
+            "faye-websocket": "0.7.3",
+            "livereload-js": "2.2.2",
+            "parseurl": "1.3.0",
+            "qs": "2.2.5"
+          },
+          "dependencies": {
+            "body-parser": {
+              "version": "1.8.4",
+              "bundled": true,
+              "requires": {
+                "bytes": "1.0.0",
+                "depd": "0.4.5",
+                "iconv-lite": "0.4.4",
+                "media-typer": "0.3.0",
+                "on-finished": "2.1.0",
+                "qs": "2.2.4",
+                "raw-body": "1.3.0",
+                "type-is": "1.5.7"
+              },
+              "dependencies": {
+                "bytes": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "depd": {
+                  "version": "0.4.5",
+                  "bundled": true
+                },
+                "iconv-lite": {
+                  "version": "0.4.4",
+                  "bundled": true
+                },
+                "media-typer": {
+                  "version": "0.3.0",
+                  "bundled": true
+                },
+                "on-finished": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "ee-first": "1.0.5"
+                  },
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.0.5",
+                      "bundled": true
+                    }
+                  }
+                },
+                "qs": {
+                  "version": "2.2.4",
+                  "bundled": true
+                },
+                "raw-body": {
+                  "version": "1.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "bytes": "1.0.0",
+                    "iconv-lite": "0.4.4"
+                  }
+                },
+                "type-is": {
+                  "version": "1.5.7",
+                  "bundled": true,
+                  "requires": {
+                    "media-typer": "0.3.0",
+                    "mime-types": "2.0.13"
+                  },
+                  "dependencies": {
+                    "mime-types": {
+                      "version": "2.0.13",
+                      "bundled": true,
+                      "requires": {
+                        "mime-db": "1.11.0"
+                      },
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.11.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "debug": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "ms": "0.6.2"
+              },
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "bundled": true
+                }
+              }
+            },
+            "faye-websocket": {
+              "version": "0.7.3",
+              "bundled": true,
+              "requires": {
+                "websocket-driver": "0.5.4"
+              },
+              "dependencies": {
+                "websocket-driver": {
+                  "version": "0.5.4",
+                  "bundled": true,
+                  "requires": {
+                    "websocket-extensions": "0.1.1"
+                  },
+                  "dependencies": {
+                    "websocket-extensions": {
+                      "version": "0.1.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "livereload-js": {
+              "version": "2.2.2",
+              "bundled": true
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "bundled": true
+            },
+            "qs": {
+              "version": "2.2.5",
+              "bundled": true
+            }
+          }
+        }
+      }
+    },
+    "ember-cli-copy-dereference": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-copy-dereference/-/ember-cli-copy-dereference-1.0.0.tgz",
+      "integrity": "sha1-oXlb9scGUDF99KuGdN0C4L6l1P0="
+    },
+    "ember-router-generator": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/ember-router-generator/-/ember-router-generator-1.2.3.tgz",
+      "integrity": "sha1-jtLKhv8yM2MSD8FCeBkeno8TFe4=",
+      "requires": {
+        "recast": "0.11.23"
+      },
+      "dependencies": {
+        "ast-types": {
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
+          "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk="
+        },
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+        },
+        "recast": {
+          "version": "0.11.23",
+          "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+          "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
+          "requires": {
+            "ast-types": "0.9.6",
+            "esprima": "3.1.3",
+            "private": "0.1.8",
+            "source-map": "0.5.7"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
+      }
+    },
+    "encodeurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
+    },
+    "engine.io": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.4.tgz",
+      "integrity": "sha1-d7zhK4Dl1gQpM3/sOw2vaR68kAM=",
+      "requires": {
+        "accepts": "1.3.3",
+        "base64id": "1.0.0",
+        "cookie": "0.3.1",
+        "debug": "2.3.3",
+        "engine.io-parser": "1.3.2",
+        "ws": "1.1.4"
+      },
+      "dependencies": {
+        "accepts": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+          "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+          "requires": {
+            "mime-types": "2.1.17",
+            "negotiator": "0.6.1"
+          }
+        },
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+        }
+      }
+    },
+    "engine.io-client": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.4.tgz",
+      "integrity": "sha1-n+hd7iWFPKa6viW9KtaHEIY+kcI=",
+      "requires": {
+        "component-emitter": "1.2.1",
+        "component-inherit": "0.0.3",
+        "debug": "2.3.3",
+        "engine.io-parser": "1.3.2",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parsejson": "0.0.3",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "ws": "1.1.2",
+        "xmlhttprequest-ssl": "1.5.3",
+        "yeast": "0.1.2"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+        },
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+        },
+        "ws": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.2.tgz",
+          "integrity": "sha1-iiRPoFJAHgjJiGz0SoUYnh/UBn8=",
+          "requires": {
+            "options": "0.0.6",
+            "ultron": "1.0.2"
+          }
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
+      "integrity": "sha1-k3sHnwAH0Ik+xW1GyyILjLQ1Igo=",
+      "requires": {
+        "after": "0.8.2",
+        "arraybuffer.slice": "0.0.6",
+        "base64-arraybuffer": "0.1.5",
+        "blob": "0.0.4",
+        "has-binary": "0.1.7",
+        "wtf-8": "1.0.0"
+      }
+    },
+    "entities": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+    },
+    "es-simpler-traverser": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/es-simpler-traverser/-/es-simpler-traverser-0.0.1.tgz",
+      "integrity": "sha1-+WmwWI8Po1N0IDrsTz2HpOYBVCE="
+    },
+    "es3-safe-recast": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es3-safe-recast/-/es3-safe-recast-2.0.2.tgz",
+      "integrity": "sha1-e/2zVXvwPygJE0jDTWtU9p6sz0s=",
+      "requires": {
+        "es-simpler-traverser": "0.0.1",
+        "recast": "0.9.18"
+      },
+      "dependencies": {
+        "ast-types": {
+          "version": "0.6.16",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.16.tgz",
+          "integrity": "sha1-BCBbcu3dGVqP6qCB8R0ClKJN7ZM="
+        },
+        "esprima-fb": {
+          "version": "10001.1.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-10001.1.0-dev-harmony-fb.tgz",
+          "integrity": "sha1-9++0UtPIAG3eazxZZ4YE9xFKiCw="
+        },
+        "recast": {
+          "version": "0.9.18",
+          "resolved": "https://registry.npmjs.org/recast/-/recast-0.9.18.tgz",
+          "integrity": "sha1-9wkhu59zfY4fsGpEAxW9fsFFh8k=",
+          "requires": {
+            "ast-types": "0.6.16",
+            "esprima-fb": "10001.1.0-dev-harmony-fb",
+            "private": "0.1.8",
+            "source-map": "0.1.43"
+          }
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
+    "es6-promise": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
+      "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esperanto": {
+      "version": "0.6.34",
+      "resolved": "https://registry.npmjs.org/esperanto/-/esperanto-0.6.34.tgz",
+      "integrity": "sha1-/gFC/fHhQj0LcNIsa6rMhl6A3tk=",
+      "requires": {
+        "acorn": "1.2.2",
+        "chalk": "1.1.3",
+        "magic-string": "0.4.9",
+        "minimist": "1.2.0",
+        "sander": "0.2.4"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "eventemitter3": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+      "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
+    },
+    "exec-sh": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
+      "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
+      "requires": {
+        "merge": "1.2.0"
+      }
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+    },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "requires": {
+        "is-posix-bracket": "0.1.1"
+      }
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "requires": {
+        "fill-range": "2.2.3"
+      }
+    },
+    "express": {
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+      "requires": {
+        "accepts": "1.3.4",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
+        "content-type": "1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "1.1.1",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "finalhandler": "1.1.0",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "2.0.2",
+        "qs": "6.5.1",
+        "range-parser": "1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.1",
+        "serve-static": "1.13.1",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.3.1",
+        "type-is": "1.6.15",
+        "utils-merge": "1.0.1",
+        "vary": "1.1.2"
+      }
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
+    },
+    "fast-sourcemap-concat": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/fast-sourcemap-concat/-/fast-sourcemap-concat-0.2.7.tgz",
+      "integrity": "sha1-tdaKbTPlL50yb+w4uDb6RNmw2Pw=",
+      "requires": {
+        "chalk": "0.5.1",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1",
+        "rsvp": "3.6.2",
+        "source-map": "0.4.4",
+        "source-map-url": "0.3.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
+        },
+        "ansi-styles": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+          "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
+        },
+        "chalk": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+          "requires": {
+            "ansi-styles": "1.1.0",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "0.1.0",
+            "strip-ansi": "0.3.0",
+            "supports-color": "0.2.0"
+          }
+        },
+        "has-ansi": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+          "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+          "requires": {
+            "ansi-regex": "0.2.1"
+          }
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+          "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+          "requires": {
+            "ansi-regex": "0.2.1"
+          }
+        },
+        "supports-color": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+          "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
+        }
+      }
+    },
+    "fb-watchman": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+      "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+      "requires": {
+        "bser": "2.0.0"
+      }
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+    },
+    "fileset": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.8.tgz",
+      "integrity": "sha1-UGuRqTluqn4y+0KoQHfHoMc2t0E=",
+      "requires": {
+        "glob": "3.2.11",
+        "minimatch": "0.4.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "requires": {
+            "inherits": "2.0.3",
+            "minimatch": "0.3.0"
+          },
+          "dependencies": {
+            "minimatch": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+              "requires": {
+                "lru-cache": "2.7.3",
+                "sigmund": "1.0.1"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
+          "integrity": "sha1-vSx9Bg0sjI/Xzefx8u0tWycP2xs=",
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
+        }
+      }
+    },
+    "fill-range": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "requires": {
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
+      }
+    },
+    "findup": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
+      "integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
+      "requires": {
+        "colors": "0.6.2",
+        "commander": "2.1.0"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
+        },
+        "commander": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+          "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E="
+        }
+      }
+    },
+    "fireworm": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/fireworm/-/fireworm-0.6.6.tgz",
+      "integrity": "sha1-YCMhjiFciuYorFEFpg5HClCYP28=",
+      "requires": {
+        "async": "0.2.10",
+        "is-type": "0.0.1",
+        "lodash": "2.3.0",
+        "minimatch": "0.2.14"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+        },
+        "lodash": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.3.0.tgz",
+          "integrity": "sha1-372smc+HpZoCLEdHMFcNhxbCZ90="
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
+        }
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "requires": {
+        "for-in": "1.0.2"
+      }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "fs-extra": {
+      "version": "0.16.5",
+      "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-0.16.5.tgz",
+      "integrity": "sha1-GtZh+myGyWCM0bSe/G/Og0k5p1A=",
+      "requires": {
+        "graceful-fs": "3.0.11",
+        "jsonfile": "2.4.0",
+        "rimraf": "2.6.2"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.2"
+      }
+    },
+    "github": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
+      "integrity": "sha1-JPp/DhP6EblGr5ETTFGYKpHOU4s=",
+      "requires": {
+        "mime": "1.6.0"
+      }
+    },
+    "glob": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+      "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+      "requires": {
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "2.0.10",
+        "once": "1.4.0"
+      }
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      }
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "requires": {
+        "is-glob": "2.0.1"
+      }
+    },
+    "graceful-fs": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+      "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+      "requires": {
+        "natives": "1.1.1"
+      }
+    },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-binary": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+      "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        }
+      }
+    },
+    "has-cors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
+    "http-errors": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+      "requires": {
+        "depd": "1.1.1",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.3.1"
+      },
+      "dependencies": {
+        "setprototypeof": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+        }
+      }
+    },
+    "http-proxy": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
+      "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
+      "requires": {
+        "eventemitter3": "1.2.0",
+        "requires-port": "1.0.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ipaddr.js": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
+      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A="
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-git-url": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/is-git-url/-/is-git-url-0.2.3.tgz",
+      "integrity": "sha1-RFIA1vvW2gKPteAUQNmvyT88y2Q="
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+    },
+    "is-type": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/is-type/-/is-type-0.0.1.tgz",
+      "integrity": "sha1-9lHYXDZdRJVdFKUdjXBh8/a0d5w=",
+      "requires": {
+        "core-util-is": "1.0.2"
+      }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isbinaryfile": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-2.0.4.tgz",
+      "integrity": "sha1-0jWS5qbwk++4TC5hUgVr4pTkFKE="
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "requires": {
+        "isarray": "1.0.0"
+      }
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "js-string-escape": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
+      "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
+    },
+    "js-yaml": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+        }
+      }
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+    },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "requires": {
+        "graceful-fs": "4.1.11"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "optional": true
+        }
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "requires": {
+        "is-buffer": "1.1.6"
+      }
+    },
+    "linkify-it": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-1.0.1.tgz",
+      "integrity": "sha1-c7MqSFTVJDj1nG4Jtt7Vvgq92Uo=",
+      "requires": {
+        "uc.micro": "1.0.3"
+      }
+    },
+    "lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+    },
+    "lodash-node": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz",
+      "integrity": "sha1-6oL3sQDHM9GkKvdoAeUGEF4qgOw="
+    },
+    "lodash._arraycopy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE="
+    },
+    "lodash._arrayeach": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+      "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754="
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+    },
+    "lodash._basefor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI="
+    },
+    "lodash._bindcallback": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
+    },
+    "lodash._createassigner": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+      "requires": {
+        "lodash._bindcallback": "3.0.1",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash.restparam": "3.6.1"
+      }
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+    },
+    "lodash.isplainobject": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+      "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
+      "requires": {
+        "lodash._basefor": "3.0.3",
+        "lodash.isarguments": "3.1.0",
+        "lodash.keysin": "3.0.8"
+      }
+    },
+    "lodash.istypedarray": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+      "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I="
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash.keysin": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+      "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
+      "requires": {
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash.merge": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
+      "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
+      "requires": {
+        "lodash._arraycopy": "3.0.0",
+        "lodash._arrayeach": "3.0.0",
+        "lodash._createassigner": "3.1.1",
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4",
+        "lodash.isplainobject": "3.2.0",
+        "lodash.istypedarray": "3.0.6",
+        "lodash.keys": "3.1.2",
+        "lodash.keysin": "3.0.8",
+        "lodash.toplainobject": "3.0.0"
+      }
+    },
+    "lodash.pad": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
+      "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA="
+    },
+    "lodash.padend": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4="
+    },
+    "lodash.padstart": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
+      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
+    },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+    },
+    "lodash.toplainobject": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+      "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keysin": "3.0.8"
+      }
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+    },
+    "magic-string": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.4.9.tgz",
+      "integrity": "sha1-9G6ar1lZz7vIj2iplpzWbRIOGiI=",
+      "requires": {
+        "vlq": "0.2.3"
+      }
+    },
+    "makeerror": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+      "requires": {
+        "tmpl": "1.0.4"
+      }
+    },
+    "markdown-it": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-4.0.3.tgz",
+      "integrity": "sha1-KoUtGIoJ65xXd7QTw8NGd/pjixg=",
+      "requires": {
+        "argparse": "1.0.9",
+        "entities": "1.1.1",
+        "linkify-it": "1.0.1",
+        "mdurl": "1.0.1",
+        "uc.micro": "1.0.3"
+      }
+    },
+    "markdown-it-terminal": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/markdown-it-terminal/-/markdown-it-terminal-0.0.2.tgz",
+      "integrity": "sha1-//LEpd8jeABjm0aKX9144hkXxPI=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "cardinal": "0.5.0",
+        "cli-table": "0.3.1",
+        "lodash-node": "3.10.2",
+        "markdown-it": "4.0.3"
+      },
+      "dependencies": {
+        "lodash-node": {
+          "version": "3.10.2",
+          "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-3.10.2.tgz",
+          "integrity": "sha1-JZjVsbVOami0y1ROXHMJU8v2Mvc="
+        }
+      }
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "merge": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "micromatch": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "requires": {
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
+      }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
+    "mime-db": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+    },
+    "mime-types": {
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "requires": {
+        "mime-db": "1.30.0"
+      }
+    },
+    "minimatch": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+      "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mktemp": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.4.0.tgz",
+      "integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws="
+    },
+    "mocha": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.21.5.tgz",
+      "integrity": "sha1-fFiwkXTfl25DSiOx6NY5hz/FKek=",
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.0.0",
+        "diff": "1.0.8",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.3",
+        "growl": "1.8.1",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+          "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+          "integrity": "sha1-ib2d9nMrUSVrxnBTQrugLtEhMe8=",
+          "dev": true,
+          "requires": {
+            "ms": "0.6.2"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+          "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+          "dev": true
+        },
+        "glob": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+          "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "2.0.3",
+            "inherits": "2.0.3",
+            "minimatch": "0.2.14"
+          }
+        },
+        "graceful-fs": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+          "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
+          "dev": true
+        },
+        "growl": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
+          "integrity": "sha1-Sy3sjZB+k9szZiTc7AGDUC+MlCg=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+          "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw=",
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "mustache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.0.tgz",
+      "integrity": "sha1-QCj3d4sXcIpImTCm5SrDvKDaQdA="
+    },
+    "natives": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.1.tgz",
+      "integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA=="
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "requires": {
+        "abbrev": "1.1.1"
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "requires": {
+        "remove-trailing-separator": "1.1.0"
+      }
+    },
+    "npmlog": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+      "integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
+      "requires": {
+        "ansi": "0.3.1",
+        "are-we-there-yet": "1.0.6",
+        "gauge": "1.2.7"
+      },
+      "dependencies": {
+        "are-we-there-yet": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
+          "integrity": "sha1-otKMkxAqpsyWJFomy5VN4G7FPww=",
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.3"
+          }
+        },
+        "gauge": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
+          "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
+          "requires": {
+            "ansi": "0.3.1",
+            "has-unicode": "2.0.1",
+            "lodash.pad": "4.5.1",
+            "lodash.padend": "4.6.1",
+            "lodash.padstart": "4.6.1"
+          }
+        }
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-component": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
+    },
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      }
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "on-headers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "options": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      }
+    },
+    "parsejson": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
+      "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
+      "requires": {
+        "better-assert": "1.0.2"
+      }
+    },
+    "parseqs": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+      "requires": {
+        "better-assert": "1.0.2"
+      }
+    },
+    "parseuri": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+      "requires": {
+        "better-assert": "1.0.2"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "pleasant-progress": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pleasant-progress/-/pleasant-progress-1.1.0.tgz",
+      "integrity": "sha1-yZzXMKLlDP/dO63/hF/E1SguJms="
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+    },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "promise-map-series": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
+      "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
+      "requires": {
+        "rsvp": "3.6.2"
+      }
+    },
+    "proxy-addr": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
+      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
+      "requires": {
+        "forwarded": "0.1.2",
+        "ipaddr.js": "1.5.2"
+      }
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+    },
+    "quick-temp": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.8.tgz",
+      "integrity": "sha1-urAqJCq4+w3XWKPJd2sy+aXZRAg=",
+      "requires": {
+        "mktemp": "0.4.0",
+        "rimraf": "2.6.2",
+        "underscore.string": "3.3.4"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "underscore.string": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
+          "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
+          "requires": {
+            "sprintf-js": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        }
+      }
+    },
+    "randomatic": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+    },
+    "raw-body": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "unpipe": "1.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "recast": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.13.0.tgz",
+      "integrity": "sha512-OwBhvGNxrL0aP5xhuVM0ms3UDYVG/uSfhfZjbPklRzoKiXukDbDmLqkfM6CtY/hkTTtAGizcMCp3XkqagctWOQ==",
+      "requires": {
+        "ast-types": "0.10.1",
+        "esprima": "4.0.0",
+        "private": "0.1.8",
+        "source-map": "0.6.1"
+      }
+    },
+    "redeyed": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.5.0.tgz",
+      "integrity": "sha1-erAA5g7jh1rBFdKe2zLBQDxsJdE=",
+      "requires": {
+        "esprima-fb": "12001.1.0-dev-harmony-fb"
+      },
+      "dependencies": {
+        "esprima-fb": {
+          "version": "12001.1.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-12001.1.0-dev-harmony-fb.tgz",
+          "integrity": "sha1-2EQAOEupXOJnjGF60kp/QICNqRU="
+        }
+      }
+    },
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "requires": {
+        "is-equal-shallow": "0.1.3"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "requires": {
+        "glob": "7.1.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
+      }
+    },
+    "rsvp": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+    },
+    "runforcover": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
+      "integrity": "sha1-NE8FfY1F0zrrxsyCIEZ49pxIV8w=",
+      "requires": {
+        "bunker": "0.1.2"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "sander": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/sander/-/sander-0.2.4.tgz",
+      "integrity": "sha1-Hca6as95aaQwTvfxNJCBpX/jUC8=",
+      "requires": {
+        "es6-promise": "2.3.0",
+        "graceful-fs": "3.0.11",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
+      }
+    },
+    "sane": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/sane/-/sane-1.7.0.tgz",
+      "integrity": "sha1-s1ebzLRclM8gNVzIESSZDf00bjA=",
+      "requires": {
+        "anymatch": "1.3.2",
+        "exec-sh": "0.2.1",
+        "fb-watchman": "2.0.0",
+        "minimatch": "3.0.4",
+        "minimist": "1.2.0",
+        "walker": "1.0.7",
+        "watch": "0.10.0"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
+    "semver": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+      "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
+    },
+    "send": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "1.1.1",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.3.1"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+      "requires": {
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
+        "send": "0.16.1"
+      }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+    },
+    "socket.io": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.4.tgz",
+      "integrity": "sha1-L37O3DORvy1cc+KR/iM+bjTU3QA=",
+      "requires": {
+        "debug": "2.3.3",
+        "engine.io": "1.8.4",
+        "has-binary": "0.1.7",
+        "object-assign": "4.1.0",
+        "socket.io-adapter": "0.5.0",
+        "socket.io-client": "1.7.4",
+        "socket.io-parser": "2.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+        },
+        "object-assign": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A="
+        }
+      }
+    },
+    "socket.io-adapter": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
+      "integrity": "sha1-y21LuL7IHhB4uZZ3+c7QBGBmu4s=",
+      "requires": {
+        "debug": "2.3.3",
+        "socket.io-parser": "2.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+        }
+      }
+    },
+    "socket.io-client": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.4.tgz",
+      "integrity": "sha1-7J+CA1btme9tNX8HVtZIcXvdQoE=",
+      "requires": {
+        "backo2": "1.0.2",
+        "component-bind": "1.0.0",
+        "component-emitter": "1.2.1",
+        "debug": "2.3.3",
+        "engine.io-client": "1.8.4",
+        "has-binary": "0.1.7",
+        "indexof": "0.0.1",
+        "object-component": "0.0.3",
+        "parseuri": "0.0.5",
+        "socket.io-parser": "2.3.1",
+        "to-array": "0.1.4"
+      },
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+        },
+        "debug": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+          "requires": {
+            "ms": "0.7.2"
+          }
+        },
+        "ms": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+        }
+      }
+    },
+    "socket.io-parser": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
+      "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
+      "requires": {
+        "component-emitter": "1.1.2",
+        "debug": "2.2.0",
+        "isarray": "0.0.1",
+        "json3": "3.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "source-map-url": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+      "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk="
+    },
+    "sprintf-js": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
+      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
+    },
+    "statuses": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "styled_string": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/styled_string/-/styled_string-0.0.1.tgz",
+      "integrity": "sha1-0ieCvYEpVFm8Tx3xjEutjpTdEko="
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "symlink-or-copy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.1.8.tgz",
+      "integrity": "sha1-yr5h4AEMHAI8Fzsl7lEIs39LSqM="
+    },
+    "tap": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-0.7.1.tgz",
+      "integrity": "sha1-vq1RNs6rgkHhsozsZjgRxjsfPn0=",
+      "requires": {
+        "buffer-equal": "0.0.2",
+        "deep-equal": "1.0.1",
+        "difflet": "0.2.6",
+        "glob": "4.5.3",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "runforcover": "0.0.2",
+        "slide": "1.1.6",
+        "yamlish": "0.0.7"
+      }
+    },
+    "temp": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.1.tgz",
+      "integrity": "sha1-S3tP/ehbsJ8t1rpsxDtEITyU/To=",
+      "requires": {
+        "rimraf": "2.2.8"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.2.8",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+        }
+      }
+    },
+    "testem": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/testem/-/testem-0.8.5.tgz",
+      "integrity": "sha1-WKfyt+LxKIJFIhyCFXrZCj8B+jc=",
+      "requires": {
+        "async": "0.9.2",
+        "backbone": "1.3.3",
+        "charm": "1.0.2",
+        "colors": "1.0.3",
+        "commander": "2.12.2",
+        "consolidate": "0.12.1",
+        "cross-spawn": "0.2.9",
+        "did_it_work": "0.0.6",
+        "express": "4.16.2",
+        "fileset": "0.1.8",
+        "fireworm": "0.6.6",
+        "glob": "5.0.15",
+        "growl": "1.10.3",
+        "http-proxy": "1.16.2",
+        "js-yaml": "3.10.0",
+        "mkdirp": "0.5.1",
+        "mustache": "2.3.0",
+        "npmlog": "1.2.1",
+        "rimraf": "2.6.2",
+        "socket.io": "1.7.4",
+        "styled_string": "0.0.1",
+        "tap": "0.7.1",
+        "xmldom": "0.1.27"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
+    "tmpl": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+    },
+    "to-array": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
+    },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+    },
+    "type-detect": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+      "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+      "dev": true
+    },
+    "type-is": {
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.17"
+      }
+    },
+    "uc.micro": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.3.tgz",
+      "integrity": "sha1-ftUNXg+an7ClczeSWfKndFjVAZI="
+    },
+    "uglify-js": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz",
+      "integrity": "sha1-7nGpfEzv0GoamyBDfzQRiYKqA1s="
+    },
+    "ultron": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+    },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+    },
+    "underscore.string": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+      "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs="
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "vlq": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
+    },
+    "walk-sync": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.1.3.tgz",
+      "integrity": "sha1-igcmGgC9ps+xviXp8QD61XVG9YM="
+    },
+    "walker": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+      "requires": {
+        "makeerror": "1.0.11"
+      }
+    },
+    "watch": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
+      "integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw="
+    },
+    "wide-align": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "requires": {
+        "string-width": "1.0.2"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "ws": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.4.tgz",
+      "integrity": "sha1-V/QNA2gy5fUFVmKjl8Tedu1mv2E=",
+      "requires": {
+        "options": "0.0.6",
+        "ultron": "1.0.2"
+      }
+    },
+    "wtf-8": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
+      "integrity": "sha1-OS2LotDxw00e4tYw8V0O+2jhBIo="
+    },
+    "xmldom": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+    },
+    "xmlhttprequest-ssl": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
+      "integrity": "sha1-GFqIjATspGw+QHDZn3tJ3jUomS0="
+    },
+    "yam": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/yam/-/yam-0.0.18.tgz",
+      "integrity": "sha1-5cq3cfD8gMpZmBTLnCacuL/wDiw=",
+      "requires": {
+        "findup": "0.1.5",
+        "fs-extra": "0.16.5",
+        "lodash.merge": "3.3.2"
+      }
+    },
+    "yamlish": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/yamlish/-/yamlish-0.0.7.tgz",
+      "integrity": "sha1-tK+aHcxjYYhzw9bkUewyE8OaV/s="
+    },
+    "yeast": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "ember-cli": "^0.2.0-beta.1",
     "lodash": "^3.5.0",
     "mkdirp": "^0.5.0",
-    "recast": "^0.9.0",
+    "recast": "^0.13.0",
     "rsvp": "^3.0.14",
     "underscore.string": "^2.3.3",
     "walk-sync": "^0.1.3"
@@ -21,7 +21,7 @@
     "chai": "^1.9.2",
     "chai-as-promised": "^4.1.1",
     "mocha": "^1.21.5",
-    "rimraf": "^2.2.8"
+    "rimraf": "^2.6.2"
   },
   "engines": ">= 0.12.0"
 }


### PR DESCRIPTION
possible fix for https://github.com/fivetanley/ember-cli-migrator/issues/68

The recast version is from 2014 and doesn't quite work with various modern javascript syntaxes